### PR TITLE
Use full GPG key fingerprint

### DIFF
--- a/docs/User-Guide_Getting-Started.md
+++ b/docs/User-Guide_Getting-Started.md
@@ -44,18 +44,18 @@ All our images are digitally signed and therefore it's possible to check theirs 
 	apt-get install gnupg p7zip
 	
 	# download public key from the database
-	gpg --keyserver pgp.mit.edu --recv-key 9F0E78D5
+	gpg --keyserver pgp.mit.edu --recv-key DF00FAF1C577104B50BF1D0093D6889F9F0E78D5
 	gpg --verify Armbian_5.18_Armada_Debian_jessie_3.10.94.img.asc
 
-	# proper respond
+	# proper response
 	gpg: Signature made sob 09 jan 2016 15:01:03 CET using RSA key ID 9F0E78D5
 	gpg: Good signature from "Igor Pecovnik (Ljubljana, Slovenia) <igor.++++++++++++@gmail.com>"
 
-	# wrong repond. Not genuine Armbian image!
+	# wrong reponse. Not genuine Armbian image!
 	gpg: Signature made Sun 03 Jan 2016 11:46:25 AM CET using RSA key ID 9F0E78D5
 	gpg: BAD signature from "Igor Pecovnik (Ljubljana, Slovenia) <igor.++++++++++++@gmail.com>"
 
-It is safe to ignore WARNING: This key is not certified with a trusted signature!
+It is safe to ignore the message `WARNING: This key is not certified with a trusted signature!`.
 
 # How to prepare a SD card?
 


### PR DESCRIPTION
when retrieving from keyserver.   It is important to use more than the old 32-bit shorthand, as they are readily faked.  See, for example, http://www.asheesh.org/note/debian/short-key-ids-are-bad-news.html and https://evil32.com/ and https://lkml.org/lkml/2016/8/15/445 (as if we needed more confirmation).