### PR TITLE
Documentation: New and fresh Docker build instructions

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -3,13 +3,13 @@
 - x86/x64 machine running any OS; 4G ram, SSD, quad core (recommended),
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or similar virtualization software **(highly recommended with a minimum of 20GB hard disk space for the virtual disk image)**,
 - Setting up VirtualBox and compile environment is easy following our [Vagrant tutorial](https://docs.armbian.com/Developer-Guide_Using-Vagrant/),
-- when you don't want to build whole OS images (`KERNEL_ONLY=yes`) then [Docker](https://github.com/igorpecovnik/lib/pull/255#issuecomment-205045273), [systemd-nspawn](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html) or other containerization software can be used,
+- when you don't want to build whole OS images (`KERNEL_ONLY=yes`) then [Docker](Developer-Guide_Building_with_Docker.md), [systemd-nspawn](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html) or other containerization software can be used,
 - **Only supported** compilation environment is [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) (**no other releases are supported**! It has to be exactly 16.04 otherwise default compiler versions might not match so if you're on an older Ubuntu release upgrade to 16.04 now, if you use a newer Ubuntu version start with 16.04 from scratch),
 - installed basic system, OpenSSH and Samba (optional),
 - no spaces in full path to the build script location allowed,
 - superuser rights (configured `sudo` or root shell).
 
-Please note that system requirements (both hardware and OS/software) may differ depending on the build environment (Vagrant, [Docker](User-Guide_Building_with_Docker.md), Virtualbox, native).
+Please note that system requirements (both hardware and OS/software) may differ depending on the build environment (Vagrant, Docker, Virtualbox, native).
 
 # How to start?
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -9,7 +9,7 @@
 - no spaces in full path to the build script location allowed,
 - superuser rights (configured `sudo` or root shell).
 
-Please note that system requirements (both hardware and OS/software) may differ depending on the build environment (Vagrant, Docker, Virtualbox, native).
+Please note that system requirements (both hardware and OS/software) may differ depending on the build environment (Vagrant, [Docker](User-Guide_Building_with_Docker.md), Virtualbox, native).
 
 # How to start?
 

--- a/docs/Developer-Guide_Building_with_Docker.md
+++ b/docs/Developer-Guide_Building_with_Docker.md
@@ -1,0 +1,48 @@
+# Building Armbian using Red Hat or CentOS
+
+## How to build my own kernel?
+
+First of all, it is important to notice that you will be able to build `kernel` and `uBoot`. The container method is not suitable for building full Armbian images (the full SD card image containing the userland packages).
+
+This setup procedure was validated to work with Red Hat Enterprise Linux 7.
+
+### Preparing your build host
+
+In order to be able to run Docker containers, if you have not done so, just install the Docker package:
+
+        # yum install -y docker
+
+By default, the `docker` service is not started upon system reboot. If you wish to do so:
+
+        # systemctl enable docker
+
+Ensure that you have the `docker` service running:
+
+        # systemctl start docker`
+
+Next step, chdir to a directory where you will be checking out the Armbian `build` repository. I use `/usr/src`. And then, check out using git (with shallow tree, using `--depth 1`, in order to speed up the process):
+
+        # cd /usr/src
+        # git clone --depth 1 https://github.com/armbian/build
+
+And in order to not mistake the newly created `build` directory, I rename it to `build-armbian`. `cd` to the directory:
+
+        # mv build build-armbian
+        # cd build-armbian
+
+### Preparing the Container
+
+Docker will now check out the correct Ubuntu image to your build enviromnent and create a Docker **image** that will used as a template for your containers. This image template will be named `armbian_dev`:
+
+        # docker build -t armbian_dev .
+
+Give it some minutes, as it downloads a non-neglectible amount of data.
+
+After your image is created (you can check it with `docker images` command), you can now spawn your container. However, by default RHEL provides only 20 GB of disk to your Container, which is not enough to a successful kernel or uBoot. So in order to overcome it, attach a volume that will bind to `/root/armbian/cache`, where the build data will be saved. In the below example, we will export the host `/mnt` to container in `/root/armbian/cache`:
+
+        # docker run -v /mnt:/root/armbian/cache armbian_dev
+
+If you want to get a shell in the container, skipping the compile script, you can also run:
+
+        # docker run -dit --entrypoint=/bin/bash -v /mnt:/root/armbian/cache armbian_dev
+

--- a/docs/Developer-Guide_Building_with_Docker.md
+++ b/docs/Developer-Guide_Building_with_Docker.md
@@ -42,7 +42,29 @@ After your image is created (you can check it with `docker images` command), you
 
         # docker run -v /mnt:/root/armbian/cache armbian_dev
 
+**NOTICE**: It is possible that SELinux might block your access to `/root/armbian/cache` because it lies outside your container. You can fix it by either adding the correct SELinux context to your **host** cache directory, or, disabling SELinux.
+
 If you want to get a shell in the container, skipping the compile script, you can also run:
 
         # docker run -dit --entrypoint=/bin/bash -v /mnt:/root/armbian/cache armbian_dev
 
+The above command will start the container with a shell. To get the shell session:
+
+        # docker attach <UUID of your container, returned in the above command>
+
+If you want to run SSH in your container, log in and install the `ssh` package:
+
+        # apt-get install -y ssh
+
+Now, define a password and prepare the settings so you `sshd` can run and you can log in as root:
+
+        # passwd
+        # sed -i -e 's/PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        # mkdir /var/run/sshd
+        # chmod 0755 /var/run/sshd
+
+And finally start `sshd`:
+
+        # /usr/sbin/sshd
+
+Do **NOT** type exit - that will terminate your container. To leave your container running after starting `sshd`, just type Ctrl-P and Ctrl-P. Now you can ssh to your container.

--- a/docs/Developer-Guide_Building_with_Docker.md
+++ b/docs/Developer-Guide_Building_with_Docker.md
@@ -67,4 +67,4 @@ And finally start `sshd`:
 
         # /usr/sbin/sshd
 
-Do **NOT** type exit - that will terminate your container. To leave your container running after starting `sshd`, just type Ctrl-P and Ctrl-P. Now you can ssh to your container.
+Do **NOT** type exit - that will stop your container. To leave your container running after starting `sshd`, just type Ctrl-P and Ctrl-P. Now you can ssh to your container.


### PR DESCRIPTION
Adding a new Docker guide book. Re-linked the main page to the new document.

While the book was tested using RHEL/CentOS, the Docker steps might work very well with other distros.

Signed-off-by: Rodrigo Freire <rbs@brasilia.br>