### PR TITLE
Introduction of the CRYPTROOT_PARAMETERS variable

### DIFF
--- a/docs/Developer-Guide_Build-Options.md
+++ b/docs/Developer-Guide_Build-Options.md
@@ -35,7 +35,7 @@
 	- set to "master" to compile from the master branch (default)
 	- set to "branchname" to compile from any other branch available ("next" & "second" are deprecated and **not** recommended to use).
 - **CARD_DEVICE** (/dev/sdx) set to the device of your SD card. The image will be burned and verified using Etcher for CLI.
-- **CRYPTROOT_ENABLE** (yes&#124;no): set to enable LUKS encrypted rootfs. You must also provide unlock password CRYPTROOT_PASSPHRASE="MYSECRECTPASS" and optional CRYPTROOT_SSH_UNLOCK=yes CRYPTROOT_SSH_PORT=2222 Function **is under testing** and works only when building in native environment, Stretch and Bionic targets only, some kernels might lack dependencies. Building under the Docker not supported yet.
+- **CRYPTROOT_ENABLE** (yes&#124;no): set to enable LUKS encrypted rootfs. You must also provide unlock password CRYPTROOT_PASSPHRASE="MYSECRECTPASS" and optional CRYPTROOT_SSH_UNLOCK=yes CRYPTROOT_SSH_UNLOCK_PORT=2222 CRYPTROOT_PARAMETERS="custom cryptsetup options" Function **is under testing** and works only when building in native environment, Stretch and Bionic targets only, some kernels might lack dependencies. Building under the Docker not supported yet.
 	
 
 ### Hidden options to minimize user input for build automation:


### PR DESCRIPTION
This commit relates to [my commit on build](https://github.com/armbian/build/pull/1182).
Further CRYPTROOT_SSH_PORT was wrong or outdated. Needs to be CRYPTROOT_SSH_UNLOCK_PORT