### PR TITLE
Increase min disk recommended 20 > 25G

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -1,7 +1,7 @@
 # What do I need?
 
 - x86/x64 machine running any OS; 4G ram, SSD, quad core (recommended),
-- [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or similar virtualization software **(highly recommended with a minimum of 20GB hard disk space for the virtual disk image)**,
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or similar virtualization software **(highly recommended with a minimum of 25GB hard disk space for the virtual disk image)**,
 - Setting up VirtualBox and compile environment is easy following our [Vagrant tutorial](https://docs.armbian.com/Developer-Guide_Using-Vagrant/),
 - [Docker](Developer-Guide_Building-with-Docker.md) environment is also supported for building kernels and full OS images,
 - **The only supported** compilation environment is [Ubuntu Bionic 18.04 x64](http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso) (**no other releases are supported**! It has to be exactly 18.04 otherwise default compiler versions might not match so if you're on an older Ubuntu release upgrade to 18.04 now, if you use a newer Ubuntu version start with 18.04 from scratch),


### PR DESCRIPTION
I did a build of nanopineo2 4.19.13-sunxi64 and it failed with a 20G disk.
I did a build with a much bigger disk and in the end it consumed 23G
Hence my 25G min recommendation