### PR TITLE
Change xenial to bionic in vagrant set up documentation

### DIFF
--- a/docs/Developer-Guide_Using-Vagrant.md
+++ b/docs/Developer-Guide_Using-Vagrant.md
@@ -20,7 +20,7 @@ Now we'll need to [install git](https://git-scm.com/downloads) and clone the Arm
 	git clone --depth 1 https://github.com/armbian/build
 
 	# Make the Vagrant box available. This might take a while but only needs to be done once.
-	vagrant box add ubuntu/xenial64
+	vagrant box add ubuntu/bionic64
 
 	# If the box gets updated by the folks at HashiCorp, we'll want to update our copy too.
 	# This only needs done once and a while.


### PR DESCRIPTION
Update documentation to refer to vagrant image "ubuntu/bionic64" instead of "ubunto/xenial64" since vagrant file was updated to xenial in https://github.com/armbian/build/commit/2c762ebd885c74eb45eb942c7d29b50d1e7a045b#diff-23b6f443c01ea2efcb4f36eedfea9089