### PR TITLE
Changed Marvell page to reflect new kernel and uboot versions and the regarding features

### DIFF
--- a/docs/Hardware_Marvell.md
+++ b/docs/Hardware_Marvell.md
@@ -1,38 +1,40 @@
-# Marvel Armada Clearfog #
+# Marvell Armada Clearfog #
 
 ## Overview ##
 
 None of kernels are fully functional so you need to try out which is best for your case.
 
-## LTS ##
-System images with patched mainline 4.4.x kernel
+## Default ##
+System images with mainline 4.14.x kernel and u-boot 2018.1
 
-- [Kernel 4.4.x](https://github.com/moonman/linux-stable)
+- [Mainline kernel](http://www.kernel.org/) with large hardware support, headers and some firmware included
 - [Docker ready](User-Guide_Advanced-Features/#how-to-run-docker)
-- Both mPCIe are operational and [convertible to mSATA](https://github.com/igorpecovnik/lib/tree/master/patch/u-boot/u-boot-armada), M2 operational
+- Both mPCIe are operational and [convertible to mSATA](https://github.com/armbian/build/tree/master/patch/u-boot/u-boot-mvebu), M2 operational
 - Added patch to unlock Atheros regulatory restrictions which unlock 5Ghz AP mode in cheap Atheros cards (ath9 driver)
 - Bluetooth ready (working with supported external keys)
 - [I2C](http://en.wikipedia.org/wiki/I%C2%B2C) ready. Basic i2c tools included.
 - [SPI](http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) ready but untested.
-- SFP ready and tested with a fibre 1G/1.25G module, requires configuring eth2 - static, DHCP or bridged (not configured by default)
+
+### Bugs or limitation ###
+
+- SFP is not supported, might work when compiling your own image with the sfp modules.
+
+## Next ##
+System images with mainline 4.19.x kernel and u-boot 2018.1
+
+- [Mainline kernel](http://www.kernel.org/) with large hardware support, headers and some firmware included
+- [Docker ready](User-Guide_Advanced-Features/#how-to-run-docker)
+- Both mPCIe are operational and [convertible to mSATA](https://github.com/armbian/build/tree/master/patch/u-boot/u-boot-mvebu), M2 operational
+- Added patch to unlock Atheros regulatory restrictions which unlock 5Ghz AP mode in cheap Atheros cards (ath9 driver)
+- Bluetooth ready (working with supported external keys)
+- [I2C](http://en.wikipedia.org/wiki/I%C2%B2C) ready. Basic i2c tools included.
+- [SPI](http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) ready but untested.
+- SFP ready and tested with a copper 1G module
 - SFP DDMI is operational (`sudo ethtool -m eth2`)
 
 ### Bugs or limitation ###
 
-- DFS (Cpufreq) is not supported
-
-## Mainline ##
-System images with mainline kernel
-
-- [Mainline kernel](http://www.kernel.org/) with large hardware support, headers and some firmware included
-- [Docker ready](User-Guide_Advanced-Features/#how-to-run-docker)
-- Both mPCIe are operational and [convertible to mSATA](https://github.com/igorpecovnik/lib/tree/master/patch/u-boot/u-boot-armada), M2 operational
-- Added patch to unlock Atheros regulatory restrictions which unlock 5Ghz AP mode in cheap Atheros cards (ath9 driver)
-- Bluetooth ready (working with supported external keys)
-
-### Bugs or limitation ###
-
-- SFP is not supported yet
+- some combination of mPCIe devices leads to incorrect/no detection, this has been observed with multiple SATA and WiFi Cards, [see here for a test matrix](https://docs.google.com/spreadsheets/d/1VggzrfFibH0cmpSGW2FyoJW-d936Y2amwwKutUwX4-8). 
 
 ## Notes
 


### PR DESCRIPTION
Hi,

as discussed here https://github.com/armbian/build/issues/1426 , I have updated the Marvell Armada docs page to reflect the new kernel versions. 

As they have been published now, please review this and merge if ok.