### PR TITLE
Update User-Guide_Getting-Started.md

### DIFF
--- a/docs/User-Guide_Getting-Started.md
+++ b/docs/User-Guide_Getting-Started.md
@@ -58,7 +58,7 @@ It is safe to ignore the message `WARNING: This key is not certified with a trus
 
 Since it might happen that your download got somehow corrupted we integrate a checksum/hash for the image. After uncompressing the download you can compare the image's SHA-256 hash with the one contained in the `sha256sum.sha` file. On Windows you can use [7-Zip's built-in hash functionality](https://superuser.com/a/1024913) to display the SHA256 hash while on Linux/macOS you would do this
 
-	shasum -a 256 -c sha256sum.sha Armbian_*.img 
+	shasum -a 256 -c Armbian_*.img.sha Armbian_*.img 
 	Armbian_5.35_Clearfogpro_Debian_stretch_next_4.13.16.img: OK
 	^C
 


### PR DESCRIPTION
So far the .sha sum files on all the Armbian images I've opened have a format  that matches the image file name, but with the suffix  .img.sha. 

As present the listed verification command fails, expecting a different, possibly out of date ? comparison file.

Replacing the -c parameter with a file spec that matches the sha file in the distribution zip file verifies as expected.

Suggest that working this out is an unnecessary hurdle in a document aimed at relatively unsophisticated users.

Harry