### PR TITLE
Fix more links after running wg.org link checking tool again

### DIFF
--- a/docs/Developer-Guide_Using-Vagrant.md
+++ b/docs/Developer-Guide_Using-Vagrant.md
@@ -8,7 +8,7 @@ The following steps are performed on the *host* that runs Vagrant.
 
 #### Virtualbox Version
 
-**WARNING:** We'll be using [Virtualbox as a virtualization provider for Vagrant](https://www.vagrantup.com/docs/providers/virtualbox/). Virtualbox has [documented issues running Xenial under heavy disk IO](https://bugs.launchpad.net/cloud-images/+bug/1616794). Please make sure your version of Virtualbox is >= 5.1.12 where the issue, ["Storage: fixed a problem with the LsiLogic SCSI controller where requests could be lost with SMP guests"](https://www.virtualbox.org/wiki/Changelog), appears to have been resolved.
+**WARNING:** We'll be using [Virtualbox as a virtualization provider for Vagrant](https://www.vagrantup.com/docs/providers/virtualbox). Virtualbox has [documented issues running Xenial under heavy disk IO](https://bugs.launchpad.net/cloud-images/+bug/1616794). Please make sure your version of Virtualbox is >= 5.1.12 where the issue, ["Storage: fixed a problem with the LsiLogic SCSI controller where requests could be lost with SMP guests"](https://www.virtualbox.org/wiki/Changelog), appears to have been resolved.
 
 First, you'll need to [install Vagrant](https://www.vagrantup.com/downloads.html) on your host box. Next, you'll need to install a plug-in that will enable us to resize the primary storage device. Without it, the default Vagrant images are too small to build Armbian.
 

--- a/docs/Hardware_Allwinner-A20.md
+++ b/docs/Hardware_Allwinner-A20.md
@@ -10,7 +10,7 @@ Both *legacy* and *current* kernels are stable and production ready and mostly s
 
 - Enabled audio devices: analog, 8 channel HDMI, spdif and I2S (if wired and enabled in HW configuration)
 - Bluetooth ready (working with supported external keys)
-- [Enabled overlayfs](/User-Guide_Advanced-Features/#how-to-freeze-your-filesystem)
+- [Enabled overlayfs](/User-Guide_Advanced-Features/#how-to-freeze-your-filesystem-outdated) (outdated)
 - [I2C](https://en.wikipedia.org/wiki/I%C2%B2C) ready and tested with small 16×2 LCD. Basic i2c tools included.
 - SPI ready and tested with ILI9341 based 2.4″ TFT LCD display.
 - [Drivers for small TFT LCD](https://github.com/notro/fbtft) display modules.
@@ -27,7 +27,7 @@ Both *legacy* and *current* kernels are stable and production ready and mostly s
 
 ### Bugs or limitation
 
-- NAND install sometime fails. Workaround: install [Lubuntu to NAND](https://dl.cubieboard.org/software/a20-cubietruck/lubuntu/) with [Phoenix tools](http://docs.cubieboard.org/downloads) and run install again.
+- NAND install sometime fails. Workaround: install [Lubuntu to NAND](http://dl.cubieboard.org/software/a20-cubietruck/lubuntu/) with [Phoenix tools](http://docs.cubieboard.org/downloads) and run install again.
 - Shutdown results into reboot under certain conditions.
 - SATA port multiplier support is disabled by default, can be enabled by adding kernel parameter `ahci_sunxi.enable_pmp=1`
 - Screen output from kernel is set to HDMI by default. Boot loader can detect and switch, kernel not.

--- a/docs/Hardware_Freescale-imx6.md
+++ b/docs/Hardware_Freescale-imx6.md
@@ -22,7 +22,7 @@ System images with legacy kernel
 System images with mainline kernel
 
 - [Mainline](https://www.kernel.org/) with large hardware support, headers and some firmware included
-- [Docker ready](/User-Guide_Advanced-Features/#how-to-run-docker) – [what is Docker](https://www.docker.com/what-docker)?
+- [Docker ready](/User-Guide_Advanced-Features/#how-to-run-docker) – [what is Docker](https://www.docker.com/why-docker)?
 - PCI-E operational (Hummingboard Pro, Gate & Edge)
 - mSATA / m2 operational (Hummingboard Pro & Edge)
 - Enabled audio devices
@@ -57,12 +57,12 @@ LVDS](https://github.com/notro/fbtft/wiki)
 
 ## GPIO
 
-[How to control HummingBoard GPIO from kernel space?](https://www.solid-run.com/community/topic2345.html)
+[How to control HummingBoard GPIO from kernel space?](http://forum.solid-run.com/viewtopic.php?forum_uri=&t=2345&start=)
 
 ## Udoo Quad
 
 - [Kernel 3.14.x](https://github.com/UDOOboard/linux_kernel) and [4.4.x](https://github.com/patrykk/linux-udoo) with some hardware support, headers and some firmware included
-- [Docker ready](https://forum.armbian.com/topic/490-docker-on-armbian/) – [what is Docker](https://www.docker.com/what-docker)?
+- [Docker ready](https://forum.armbian.com/topic/490-docker-on-armbian/) – [what is Docker](https://www.docker.com/why-docker)?
 - Wireless adapter with DHCP ready but disabled (/etc/network/interfaces, WPA2: normal connect, bonding / notebook or AP mode). It can handle between 40-70Mbit/s.
 - SATA operational
 - Enabled analogue (VT1613) and HDMI audio device

--- a/docs/Process_Release-Model.md
+++ b/docs/Process_Release-Model.md
@@ -143,7 +143,7 @@ The goal of this thread is to discuss testing, bugfixes, and the overall quality
 
 - For code freeze -- create a RC branch as `version-rc` ex: `v20.02.0-rc`
 - If Possible, create Jira tickets for major changes in github that were not tracked in Jira
-- Begin Testing Process.  See [Release Testing](#Release_Testing)
+- Begin Testing Process.  See [Release Testing](#release-testing)
 - Do not modify branch directy.  Only accept PRs
 - Only accept PRs for Bugfixes. No features
 - Update master branch version to the NEXT release version with `-trunk`  ex. If RC is v20.02.0-rc Master bacomes v20.05.0-trunk

--- a/docs/Release_Changelog.md
+++ b/docs/Release_Changelog.md
@@ -1450,7 +1450,7 @@ Known bugs:
 - added Marvel Armada kernel 3.10.96, 4.4.1 and patches for changing mPCI to SATA
 - added Cubox / Hummingboard kernel 4.4.1 (serial console only)
 - firstrun does autoreboot only if needed: wheezy and some legacy kernels.
-- [added motd](https://forum.armbian.com/topic/602-new-motd-for-ubuntudebian/?do=findComment&comment=4223) to /etc/updated.motd ... redesign, added battery info for Allwinner boards, bugfix, coloring
+- [added motd](https://forum.armbian.com/topic/602-new-motd-for-ubuntudebian/?tab=comments#comment-4223) to /etc/updated.motd ... redesign, added battery info for Allwinner boards, bugfix, coloring
 - fixed temperature reading on Cubox / Hummingboard legacy kernel
 - fixed FB turbo building on Allwinner
 - fixed NAND install on A10 boards (Legacy kernel only)

--- a/docs/User-Guide_Advanced-Features.md
+++ b/docs/User-Guide_Advanced-Features.md
@@ -133,7 +133,7 @@ Required conditions:
 - IR hardware
 - loaded driver
 
-Get your [remote configuration](https://lirc.sourceforge.net/remotes/) (lircd.conf) or [learn](https://kodi.wiki/view/HOW-TO:Setup_Lirc#Learning_Commands).
+Get your [remote configuration](http://lirc.sourceforge.net/remotes/) (lircd.conf) or [learn](https://kodi.wiki/view/HOW-TO:Setup_Lirc#Learning_Commands).
 
 - Note: As of 2020-11-25, the above (Kodi / learn) link is broken.  However I am not sure what to replace it with.  If you know (or find out) please [submit a PR](/Process_Contribute/).  - TRS-80
 

--- a/docs/User-Guide_Armbian-Config.md
+++ b/docs/User-Guide_Armbian-Config.md
@@ -69,7 +69,7 @@ Software installation menu provides automated install of the following packages.
 	- [UrBackup](https://www.urbackup.org/) *(client/server backup system)*
 	- [Docker](https://www.docker.com) *(Docker CE engine)*
 	- [Mayan EDMS](https://www.mayan-edms.com/) *(Document management system within Docker)*
-	- [MiniDLNA](https://minidlna.sourceforge.net/) *(media sharing)*
+	- [MiniDLNA](http://minidlna.sourceforge.net/) *(media sharing)*
 - **M**onitor = simple CLI monitoring 
 - **D**iagnostics = create a summary of logs and upload them to paste.bin
 - **T**oggle kernel headers, RDP service, Thunderbird and Libreoffice (desktop builds)

--- a/docs/User-Guide_Fine-Tuning.md
+++ b/docs/User-Guide_Fine-Tuning.md
@@ -92,7 +92,7 @@ This example is for H3 legacy kernel. Check [this page](https://www.armbian.com/
 
 ## How to toggle boot output?
 
-Edit and change [boot parameters](https://redsymbol.net/linux-kernel-boot-parameters/) in `/boot/boot.cmd` (not recommended) or variables in `/boot/armbianEnv.txt`:
+Edit and change [boot parameters](http://redsymbol.net/linux-kernel-boot-parameters/) in `/boot/boot.cmd` (not recommended) or variables in `/boot/armbianEnv.txt`:
 
     - console=both
     + console=serial

--- a/docs/User-Guide_Getting-Started.md
+++ b/docs/User-Guide_Getting-Started.md
@@ -84,7 +84,7 @@ while on Linux/macOS, in the directory in which you have downloaded the files ,y
 
 ## How to prepare a SD card?
 
-**Important note:** Make sure you use a **good, reliable and fast** SD card. If you encounter boot or stability troubles in over 95 percent of the time it is either insufficient power supply or related to SD card (bad card, bad card reader, something went wrong when burning the image, card too slow to boot -- 'Class 10' highly recommended!). Armbian can simply not run on unreliable hardware so checking your SD card with either [F3](https://oss.digirati.com.br/f3/) or [H2testw](https://www.heise.de/download/product/h2testw-50539) is mandatory if you run in problems. Since [counterfeit SD cards](https://www.happybison.com/reviews/how-to-check-and-spot-fake-micro-sd-card-8/) are still an issue checking with F3/H2testw directly after purchase is **highly recommended**.
+**Important note:** Make sure you use a **good, reliable and fast** SD card. If you encounter boot or stability troubles in over 95 percent of the time it is either insufficient power supply or related to SD card (bad card, bad card reader, something went wrong when burning the image, card too slow to boot -- 'Class 10' highly recommended!). Armbian can simply not run on unreliable hardware so checking your SD card with either [F3](https://oss.digirati.com.br/f3/) (2020-11-27 link broken, [archive](https://web.archive.org/web/20201112035459/http://oss.digirati.com.br/f3/)) or [H2testw](https://www.heise.de/download/product/h2testw-50539) is mandatory if you run in problems. Since [counterfeit SD cards](https://www.happybison.com/reviews/how-to-check-and-spot-fake-micro-sd-card-8/) are still an issue checking with F3/H2testw directly after purchase is **highly recommended**.
 
 Write the xz compressed image  with [USBImager](https://gitlab.com/bztsrc/usbimager) or [Etcher](https://balena.io/etcher/) on all platforms since unlike other tools, either can validate  burning results **saving you from corrupted SD card contents**.
 
@@ -99,7 +99,7 @@ At the time of this writing A1 and A2 cards are only widely available from SanDi
 
 ![a1-16gb-card](https://raw.githubusercontent.com/armbian/documentation/master/docs/images/sandisk-ultra-a1.png) ![a1-32gb-card](https://raw.githubusercontent.com/armbian/documentation/master/docs/images/sandisk-extremepro-a1.png) ![a2-64gb-card](https://raw.githubusercontent.com/armbian/documentation/master/docs/images/sandisk-extreme-a2.png)
 
-In case you chose an SD card that was already in use before please consider resetting it back to 'factory default' performance with [SD Formatter](https://www.sdcard.org/downloads/formatter/) before burning Armbian to it ([explanation in the forum](https://forum.armbian.com/topic/3776-the-partition-is-not-resized-to-full-sd-card-size/&do=findComment&comment=27413)). Detailed information regarding ['factory default' SD card performance](https://forum.armbian.com/topic/954-sd-card-performance/?page=3&tab=comments#comment-49811).
+In case you chose an SD card that was already in use before please consider resetting it back to 'factory default' performance with [SD Formatter](https://www.sdcard.org/downloads/formatter/) before burning Armbian to it ([explanation in the forum](https://forum.armbian.com/topic/3776-the-partition-is-not-resized-to-full-sd-card-size/&do=findComment&comment=27413)). Detailed information regarding ['factory default' SD card performance](https://forum.armbian.com/topic/954-sd-card-performance/page/3/&tab=comments#comment-49811).
 
 ## How to boot?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,6 @@ Check [download page](https://www.armbian.com/download/) for recently supported 
 
 * [Contribute](Process_Contribute/)
 * [Community](https://forum.armbian.com/)
-* [Contact](https://www.armbian.com/contact/)
+* [Contact](https://www.armbian.com/#contact)
 
 Our IRC channel is [#armbian](https://webchat.freenode.net/?channels=armbian) on [freenode](https://freenode.net/). More details [here](https://docs.armbian.com/Community_IRC/)


### PR DESCRIPTION
Many less links this time around.  However I want to note the various
reasons there were still some broken links:

In some cases, it was because httpS is not supported on some sites
where I might have expected it to be (Sourceforge, etc.) and were
(perhaps too optimistically) changed in last (mass) http to httpS
update.

In other cases, previously updated links needed to be updated to their
final redirect location, which could not be seen (easily) until the
changes went live.

In other cases, there were more than one link to same site with the
same problem, and I had only searched for one link on the page (and
thus missed the others).

And finally, in at least one case (F3) it appears the site already
went down in the meantime.

All of above cases should now be remedied.  However I do plan on
running the link checker (at least) one more time again once this
latest batch of changes go live, just to make sure.