### PR TITLE
Added device tree setup section to IMX6 documentation

### DIFF
--- a/docs/Hardware_Freescale-imx6.md
+++ b/docs/Hardware_Freescale-imx6.md
@@ -28,6 +28,30 @@ System images with mainline kernel
 - Enabled audio devices
 - Bluetooth ready (working with supported external keys)
 
+### Set board type
+By default the mainline Hummingboard / Cubox-i Armbian images are configured for the Cubox-I with a dual or quad core 
+SOM. 
+
+To run the image on another platform or SOM the correct device tree file needs to be specified. These files are stored in
+`/boot/dtb`. To set the correct device tree blow a `fdt_file=` parameter needs to be added to `/boot/armbianEnv.txt`. 
+
+Set the `fdt_file=` parameter according to the list below:
+
+IMX6 Solo / DualLite:
+
+- [Hummingboard] `fdt_file=imx6dl-hummingboard.dtb`
+- [Hummingboard v2] `fdt_file=imx6dl-hummingboard2.dtb`
+- [Cubox-I] `fdt_file=imx6dl-cubox-i.dtb`
+
+IMX6 Dual / Quad:
+
+- [Hummingboard] `fdt_file=imx6q-hummingboard.dtb`
+- [Hummingboard v2] `fdt_file=imx6q-hummingboard2.dtb`
+- [Cubox-I] `fdt_file=imx6q-cubox-i.dtb` (Default)
+  
+If a v1.5 SOM (with eMMC) is used the device tree names need to be changed, e.g.: `imx6q-cubox-i-som-v15.dtb` or 
+`imx6q-cubox-i-emmc-som-v15.dtb`.
+
 ### Bugs or limitation
 
 - Gigabit ethernet transfer rate is around 50% of its theoretical max rate (internal chip bus limitation)

--- a/docs/User-Guide_Basic-Troubleshooting.md
+++ b/docs/User-Guide_Basic-Troubleshooting.md
@@ -60,10 +60,13 @@ Note that
 - Most commonly low capacity cards will be reprogrammed to appear as bigger, but any files written beyond the true capacity will be lost or corrupted.
 - We recommend to always [test the capacity of each new SD cards using f3](https://fight-flash-fraud.readthedocs.io/en/latest/usage.html).
 
-
 ### Writing images to the SD card
 
 - If you wrote an image to the card it does not mean that it was written successfully without any errors
 - so always verify images after write using some tools like _balenaEtcher_ which is currently the only popular and cross-platform tool that does mandatory verify on write (more lightweight alternatives may be added to this page in the future)
 - "Check for bad blocks" function available in some tools is mostly useless when dealing with SD cards
 - Note that _balenaEtcher_ verifies only 1-2GB that are occupied by the initial unresized image, it does not verify the whole SD card
+
+## Configuration
+
+- Some boards require the setup of the correct device tree file or they will not boot. Check the board specific documentation for details.


### PR DESCRIPTION
The default Cubox-I / Hummingboard image have fdt_file set to imx6q-cubox-i.dbt and will not boot by default on a Hummingboard.