### PR TITLE
About linux-$KERNELFAMILY-$KERNELBRANCH.config

### DIFF
--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -23,6 +23,7 @@ If file `userpatches/linux-$KERNELFAMILY-$KERNELBRANCH.config` exists, it will b
 
     [ o.k. ] Compiling edge kernel [ @host ]
     [ o.k. ] Using kernel config file [ config/linux-sunxi-edge.config ]
+Where KERNELBRANCH is BRANCH and KERNELFAMILY is LINUXFAMILY from https://docs.armbian.com/Developer-Guide_Build-Preparation/
 
 ## User provided sources config overrides
 


### PR DESCRIPTION
it is very hard to understand this 
linux-$KERNELFAMILY-$KERNELBRANCH.config

Example ("the file name is linux-rockchip64-current.config") is good but not enough
I spend about week to understand that for my build script BOARD=orangepi4 BRANCH=current RELEASE=hirsute

There are  BRANCH and LINUXFAMILY in armbian doc https://docs.armbian.com/Developer-Guide_Build-Preparation 
It is hard to understand that BRANCH==KERNELBRANCH and KERNELFAMILY==LINUXFAMILY!!!

I also suggest rename KERNELBRANCH to BRANCH and KERNELFAMILY to LINUXFAMILY! 
@Miouyouyou