### PR TITLE
Example of User provided kernel config

### DIFF
--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -21,8 +21,8 @@ If file `userpatches/lib.config` exists, it will be called and can override the 
 
 If file `userpatches/linux-$LINUXFAMILY-$RANCH.config` exists, it will be used instead of default one from `config`. Look for the hint at the beginning of kernel compilation process to select proper config file name. Example:
 
-    [ o.k. ] Compiling edge kernel [ @host ]
-    [ o.k. ] Using kernel config file [ config/linux-sunxi-edge.config ]
+    [ o.k. ] Compiling curent kernel [ 5.10.47 ]
+    [ o.k. ] Using kernel config provided by user [ userpatches/linux-rockchip64-current.config ]
 
 ## User provided sources config overrides
 

--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -19,7 +19,7 @@ If file `userpatches/lib.config` exists, it will be called and can override the 
 
 ## User provided kernel config
 
-If file `userpatches/linux-$LINUXFAMILY-$RANCH.config` exists, it will be used instead of default one from `config`. Look for the hint at the beginning of kernel compilation process to select proper config file name. Example:
+If file `userpatches/linux-$LINUXFAMILY-$BRANCH.config` exists, it will be used instead of default one from `config`. Look for the hint at the beginning of kernel compilation process to select proper config file name. Example:
 
     [ o.k. ] Compiling curent kernel [ 5.10.47 ]
     [ o.k. ] Using kernel config provided by user [ userpatches/linux-rockchip64-current.config ]

--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -21,7 +21,7 @@ If file `userpatches/lib.config` exists, it will be called and can override the 
 
 If file `userpatches/linux-$LINUXFAMILY-$BRANCH.config` exists, it will be used instead of default one from `config`. Look for the hint at the beginning of kernel compilation process to select proper config file name. Example:
 
-    [ o.k. ] Compiling curent kernel [ 5.10.47 ]
+    [ o.k. ] Compiling current kernel [ 5.10.47 ]
     [ o.k. ] Using kernel config provided by user [ userpatches/linux-rockchip64-current.config ]
 
 ## User provided sources config overrides


### PR DESCRIPTION
Look at https://forum.armbian.com/topic/6-how-to-build-my-own-image-or-kernel/?do=findComment&comment=126636 
Old example is not actual, modern armbian has only BRANCH ( **legacy** | **current** | **dev** ) not **edge** because https://docs.armbian.com/Developer-Guide_Build-Options/ 
and "sunxi" looks not like a LINUXFAMILY but like a fake. (May be "sun7i"?) I think that armbian never can make this example message.

My example is real example from my system.