### PR TITLE
armbianEnv.txt secrets

### DIFF
--- a/docs/User-Guide_Fine-Tuning.md
+++ b/docs/User-Guide_Fine-Tuning.md
@@ -111,7 +111,13 @@ Recompile boot.cmd to boot.scr if it was changed:
 
 Reboot.
 
-Serial console on imx6 boards are ttymxc0 (Hummingboard, Cubox-i) or ttymxc1 (Udoo).
+Serial console on imx6 boards are ttymxc0 (Hummingboard, Cubox-i) or ttymxc1 (Udoo); ttyS2 for Orange Pi 4.
+If you want switch off Linux System Serial Port for Console Management:
+    - console=both
+    + console=none
+In this case U-boot does not pass bootargs variable with console parameters to Linux kernel.
+
+Note: If you just edit armbianEnv.txt or boot.cmd on your microSD then no effect for U-Boot because U-Boot use boot.scr. To get new boot.scr you need use mkimage, see above.
 
 ## How to toggle verbose boot?
 


### PR DESCRIPTION
Here I am talking how disable passing console args to linux kernel. It is interesting for user if user wants use extra UART for themself. For example there are only 2 UARTs on Orange Pi 4B, one of them - debug UART. 

Details https://forum.armbian.com/topic/18576-bootarmbianenvtxt-vs-buildconfigbootenvrockchiptxt/

______________________________________________
2) In [second](https://github.com/armbian/build/commit/9280c7901c0c681db32d36e50a28cc4577081bcc#commitcomment-53244935) commit I try look at 
How  how disable agetty.