### PR TITLE
add boards list via hyperlink

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -50,6 +50,7 @@ Example:
     ./compile.sh BOARD=cubietruck BRANCH=current KERNEL_ONLY=no RELEASE=focal
 
 Note: Option `BUILD_ALL` cannot be set to "yes" via command line parameter.
+Note: Full boards list with right names you can get [using](https://github.com/armbian/build/tree/master/config/boards). For example there is file orangepi4.conf so ${BOARD}=orangepi4 
 
 ### Base and descendant configuration
 


### PR DESCRIPTION
it is [real](https://github.com/armbian/documentation/pull/125#issuecomment-875118130) to set ${BOARD} ${RELEASE} and others via hyperlink in armbian docs. User wants push to ${BOARD} and to see list. Look at me: I have got Orange Pi 4B (not just 4), my first question - what is ${BOARD}? May be orangepi4 or ORANGEPI4 or orange_pi_4_b ?

Thanks [Miouyouyou](https://github.com/armbian/documentation/pull/125#issuecomment-876410513)