### PR TITLE
mkdocs.yml: Comment out PDF automatic generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,11 +11,14 @@ theme:
 
 plugins:
     - search:
-    - with-pdf:
-        author: Armbian documentation team
-        copyright: © 2021 by Armbian
-        cover_title: Armbian documentation
-        cover_subtitle: Linux for ARM development boards
+    # NOTE: See https://github.com/armbian/documentation/issues/171
+    # (TRS-80 2022-02-01)
+    #
+    # - with-pdf:
+    #     author: Armbian documentation team
+    #     copyright: © 2021 by Armbian
+    #     cover_title: Armbian documentation
+    #     cover_subtitle: Linux for ARM development boards
 
 markdown_extensions:
   - smarty


### PR DESCRIPTION
Since we are not using it anyway.

This reduces local mkdocs re-generation from minutes to seconds.

It also prevents almost 10K lines of binary (document.pdf) from being
added to the docs repo with every PR.

See also: https://github.com/armbian/documentation/issues/171.