### PR TITLE
.github/workflows/recreate_on_push.yaml: Fix PDF breakage

### DIFF
--- a/.github/workflows/recreate_on_push.yaml
+++ b/.github/workflows/recreate_on_push.yaml
@@ -26,30 +26,32 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel
-        pip install mkdocs mkdocs-with-pdf
+        pip install mkdocs # mkdocs-with-pdf
     - name: Run mkdocs --clean
       run: |
         mkdocs build --clean
-        
-    - name: Upload pdf 
-      uses: actions/upload-artifact@v2
-      with:
-        name: artifact
-        path: site/pdf/document.pdf
+
+    # See: https://github.com/armbian/documentation/issues/96
+    # 
+    # - name: Upload pdf 
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: artifact
+    #     path: site/pdf/document.pdf
         
   Deploy:
     needs: [ build ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
+      # - uses: actions/download-artifact@v2
+      #   with:
+      #     name: artifact
       - name: Add
         run: |
           ls -l
           git pull
-          git add document.pdf
+          # git add document.pdf
       - name: Commit files
         run: |
           git config --local user.email "info@armbian.com"


### PR DESCRIPTION
Previously I had commented out auto-generation of
PDF (https://github.com/armbian/documentation/pull/176), but that
seems to have broken some Actions here, which seem to look for the
PDF.

With this I hope to fix it.