### PR TITLE
docs/Release_Board-Maintainers.md: Update antondeveloper GitHub

### DIFF
--- a/docs/Release_Board-Maintainers.md
+++ b/docs/Release_Board-Maintainers.md
@@ -4,102 +4,102 @@ Where more than one Maintainer is listed, the first (top line, with BOARDCONF) p
 
 Maintainer column, in this table, is GitHub user name.  For cross reference to forum handle, see [Forum Name Cross Reference](#forum-name-cross-reference) (below).
 
-| BOARDCONF            | Maintainer     | Note(s)            |
-|----------------------|----------------|--------------------|
-| bananapi             | janprunk       |                    |
-| bananapim2plus       | igorpecovnik   |                    |
-| bananapim64          | antondeveloper | [3](#n3)           |
-| bananapipro          | igorpecovnik   |                    |
-| clearfogbase         | heisath        |                    |
-| clearfogpro          | heisath        |                    |
-| cubieboard           |                |                    |
-| cubietruck           |                |                    |
-| cubox-i              | igorpecovnik   |                    |
-| firefly-rk3399       | 150balbes      |                    |
-| helios4              | heisath        |                    |
-| jethubj100           |                |                    |
-| jethubj80            |                |                    |
-| jetson-nano          | 150balbes      |                    |
-| khadas-edge          | igorpecovnik   |                    |
-| khadas-vim1          |                | [1](#n1)           |
-| khadas-vim2          |                | [1](#n1)           |
-| khadas-vim3          | NicoD-SBC      |                    |
-| khadas-vim3l         |                | [1](#n1), [2](#n2) |
-| lafrite              | Tonymac32      |                    |
-| lepotato             | Tonymac32      |                    |
-| lime-a64             | igorpecovnik   |                    |
-| lime2                | igorpecovnik   |                    |
-| nanopct4             | 150balbes      |                    |
-| nanopi-r1            | igorpecovnik   |                    |
-| nanopi-r2s           | igorpecovnik   |                    |
-| nanopi-r4s           | piter75        |                    |
-| nanopiair            |                |                    |
-| nanopiduo            |                |                    |
-| nanopiduo2           |                |                    |
-| nanopik1plus         | igorpecovnik   |                    |
-| nanopik2-s905        | igorpecovnik   |                    |
-| nanopim4             | piter75        |                    |
-| nanopim4v2           | piter75        |                    |
-| nanopineo            | igorpecovnik   |                    |
-| nanopineo2           | igorpecovnik   |                    |
-| nanopineo2black      | igorpecovnik   |                    |
-| nanopineo3           |                |                    |
-| nanopineo4           |                |                    |
-| nanopineocore2       |                |                    |
-| nanopineoplus2       | teknoid        |                    |
-| odroidc2             | NicoD-SBC      | [1](#n1)           |
-| odroidc4             |                | [1](#n1)           |
-| odroidhc4            | rpardini       |                    |
-| odroidn2             | rpardini       |                    |
-| odroidxu4            | igorpecovnik   |                    |
-| "                    | joekhoobyar    |                    |
-| orangepi-r1          | igorpecovnik   |                    |
-| orangepi-r1plus      |                |                    |
-| orangepi-rk3399      |                |                    |
-| orangepi2            |                |                    |
-| orangepi3            | igorpecovnik   |                    |
-| orangepi4            | igorpecovnik   |                    |
-| orangepilite         | igorpecovnik   |                    |
-| orangepilite2        | igorpecovnik   |                    |
-| orangepione          | igorpecovnik   |                    |
-| orangepioneplus      | igorpecovnik   |                    |
-| orangepipc           | lbmendes       |                    |
-| orangepipc2          | igorpecovnik   |                    |
-| orangepipcplus       | igorpecovnik   |                    |
-| orangepiplus         |                |                    |
-| orangepiplus2e       | igorpecovnik   |                    |
-| orangepiprime        | igorpecovnik   |                    |
-| orangepiwin          | igorpecovnik   |                    |
-| orangepizero         | igorpecovnik   |                    |
-| orangepizero2        | krachlatte     |                    |
-| orangepizeroplus     | igorpecovnik   |                    |
-| orangepizeroplus2-h3 |                |                    |
-| orangepizeroplus2-h5 |                |                    |
-| pine64               | janprunk       |                    |
-| pinebook-a64         | igorpecovnik   |                    |
-| pinebookpro          | seclorum       |                    |
-| pineh64-b            |                |                    |
-| radxa-n10            |                |                    |
-| radxa-zero           | RadxaYuntian   | [3](#n3)           |
-| renegade             | Tonymac32      |                    |
-| rock-3a              | catalinii      |                    |
-| "                    | ZazaBr         | [3](#n3)           |
-| rockpi-4a            |                |                    |
-| rockpi-4b            |                |                    |
-| rockpi-4c            |                |                    |
-| rockpi-e             |                |                    |
-| rockpi-s             |                |                    |
-| rockpro64            | joekhoobyar    |                    |
-| station-m1           | 150balbes      |                    |
-| station-p1           | 150balbes      |                    |
-| teres-a64            |                |                    |
-| tinkerboard          | Tonymac32      |                    |
-| tritium-h3           |                |                    |
-| tritium-h5           |                |                    |
-| udoo                 |                |                    |
-| zeropi               | igorpecovnik   |                    |
-| station-m2           | 150balbes      |                    |
-| station-p2           | 150balbes      |                    |
+| BOARDCONF            | Maintainer   | Note(s)            |
+|----------------------|--------------|--------------------|
+| bananapi             | janprunk     |                    |
+| bananapim2plus       | igorpecovnik |                    |
+| bananapim64          | devdotnetorg |                    |
+| bananapipro          | igorpecovnik |                    |
+| clearfogbase         | heisath      |                    |
+| clearfogpro          | heisath      |                    |
+| cubieboard           |              |                    |
+| cubietruck           |              |                    |
+| cubox-i              | igorpecovnik |                    |
+| firefly-rk3399       | 150balbes    |                    |
+| helios4              | heisath      |                    |
+| jethubj100           |              |                    |
+| jethubj80            |              |                    |
+| jetson-nano          | 150balbes    |                    |
+| khadas-edge          | igorpecovnik |                    |
+| khadas-vim1          |              | [1](#n1)           |
+| khadas-vim2          |              | [1](#n1)           |
+| khadas-vim3          | NicoD-SBC    |                    |
+| khadas-vim3l         |              | [1](#n1), [2](#n2) |
+| lafrite              | Tonymac32    |                    |
+| lepotato             | Tonymac32    |                    |
+| lime-a64             | igorpecovnik |                    |
+| lime2                | igorpecovnik |                    |
+| nanopct4             | 150balbes    |                    |
+| nanopi-r1            | igorpecovnik |                    |
+| nanopi-r2s           | igorpecovnik |                    |
+| nanopi-r4s           | piter75      |                    |
+| nanopiair            |              |                    |
+| nanopiduo            |              |                    |
+| nanopiduo2           |              |                    |
+| nanopik1plus         | igorpecovnik |                    |
+| nanopik2-s905        | igorpecovnik |                    |
+| nanopim4             | piter75      |                    |
+| nanopim4v2           | piter75      |                    |
+| nanopineo            | igorpecovnik |                    |
+| nanopineo2           | igorpecovnik |                    |
+| nanopineo2black      | igorpecovnik |                    |
+| nanopineo3           |              |                    |
+| nanopineo4           |              |                    |
+| nanopineocore2       |              |                    |
+| nanopineoplus2       | teknoid      |                    |
+| odroidc2             | NicoD-SBC    | [1](#n1)           |
+| odroidc4             |              | [1](#n1)           |
+| odroidhc4            | rpardini     |                    |
+| odroidn2             | rpardini     |                    |
+| odroidxu4            | igorpecovnik |                    |
+| "                    | joekhoobyar  |                    |
+| orangepi-r1          | igorpecovnik |                    |
+| orangepi-r1plus      |              |                    |
+| orangepi-rk3399      |              |                    |
+| orangepi2            |              |                    |
+| orangepi3            | igorpecovnik |                    |
+| orangepi4            | igorpecovnik |                    |
+| orangepilite         | igorpecovnik |                    |
+| orangepilite2        | igorpecovnik |                    |
+| orangepione          | igorpecovnik |                    |
+| orangepioneplus      | igorpecovnik |                    |
+| orangepipc           | lbmendes     |                    |
+| orangepipc2          | igorpecovnik |                    |
+| orangepipcplus       | igorpecovnik |                    |
+| orangepiplus         |              |                    |
+| orangepiplus2e       | igorpecovnik |                    |
+| orangepiprime        | igorpecovnik |                    |
+| orangepiwin          | igorpecovnik |                    |
+| orangepizero         | igorpecovnik |                    |
+| orangepizero2        | krachlatte   |                    |
+| orangepizeroplus     | igorpecovnik |                    |
+| orangepizeroplus2-h3 |              |                    |
+| orangepizeroplus2-h5 |              |                    |
+| pine64               | janprunk     |                    |
+| pinebook-a64         | igorpecovnik |                    |
+| pinebookpro          | seclorum     |                    |
+| pineh64-b            |              |                    |
+| radxa-n10            |              |                    |
+| radxa-zero           | RadxaYuntian | [3](#n3)           |
+| renegade             | Tonymac32    |                    |
+| rock-3a              | catalinii    |                    |
+| "                    | ZazaBr       | [3](#n3)           |
+| rockpi-4a            |              |                    |
+| rockpi-4b            |              |                    |
+| rockpi-4c            |              |                    |
+| rockpi-e             |              |                    |
+| rockpi-s             |              |                    |
+| rockpro64            | joekhoobyar  |                    |
+| station-m1           | 150balbes    |                    |
+| station-p1           | 150balbes    |                    |
+| teres-a64            |              |                    |
+| tinkerboard          | Tonymac32    |                    |
+| tritium-h3           |              |                    |
+| tritium-h5           |              |                    |
+| udoo                 |              |                    |
+| zeropi               | igorpecovnik |                    |
+| station-m2           | 150balbes    |                    |
+| station-p2           | 150balbes    |                    |
 
 Notes (for above):
 <ol>
@@ -120,7 +120,7 @@ Please make a forum post in the appropriate place instead.
 
 | GitHub       | Forum Name     |
 |--------------|----------------|
-| ?            | antondeveloper |
+| devdotnetorg | antondeveloper |
 | 150balbes    | balbes150      |
 | catalinii    | catalinii      |
 | heisath      | Heisath        |


### PR DESCRIPTION
antondeveloper is devdotnetorg on GitHub.

The reason the whole table was replaced, was because when I moved the
note 3 after his name, it changed the column width.  But there were no
other changes.