### PR TITLE
Fix bizarre enumerated list nonsense

### DIFF
--- a/docs/Developer-Guide_Building-with-Docker.md
+++ b/docs/Developer-Guide_Building-with-Docker.md
@@ -23,15 +23,15 @@ Installation (https://docs.docker.com/engine/install/)
 
 There are 3 options to start build process:
 
-1. By passing configuration file name (`config-<conf_name>.conf`), stored in `userpatches` directory, as an argument:
+1\. By passing configuration file name (`config-<conf_name>.conf`), stored in `userpatches` directory, as an argument:
 ```
 ./compile.sh docker <conf_name>
 ```
-2. By passing addtional line arguments to `compile.sh` after `docker`:
+2\. By passing addtional line arguments to `compile.sh` after `docker`:
 ```
 ./compile.sh docker KERNEL_ONLY=yes BOARD=cubietruck BRANCH=current KERNEL_CONFIGURE=yes
 ```
-3. Interactively run inside docker container
+3\. Interactively run inside docker container
 ```
 ./compile.sh docker-shell BOARD=rockpi-4a BRANCH=edge RELEASE=focal
 ```


### PR DESCRIPTION
For some reason, Markdown's enumerated lists are awful to deal with. This caused the (1. 2. 3.) list on docs.armbian.com to show up as (1. 1. 1.) This fix doesn't look right on GitHub but *should* render correctly on the site itself.
https://stackoverflow.com/a/63226685/12559797