### PR TITLE
Update Developer-Guide_Build-Options.md

### DIFF
--- a/docs/Developer-Guide_Build-Options.md
+++ b/docs/Developer-Guide_Build-Options.md
@@ -75,6 +75,7 @@ These parameters are meant to be applied to the `./compile.sh` command. They are
 - **PROGRESS_DISPLAY** ( none | **plain** | dialog ): way to display output of verbose processes - compilation, packaging, debootstrap
 - **PROGRESS_LOG_TO_FILE** ( yes | **no** ): duplicate output, affected by previous option, to log files `output/debug/*.log`
 - **NO_APT_CACHER** ( **yes** | no ): disable usage of APT cache. Default `yes` in containers, but can be overridden
+- **DISABLE_IPV6** ( **true** | false ): The distant future, the year Two-Thousand.  Set false to allow Aria2c to use a modern ip protocol.
 - **NO_HOST_RELEASE_CHECK** ( yes | **no** ): overrides the check for a supported host system
 - **USE_MAINLINE_GOOGLE_MIRROR** ( yes | **no** ): use `googlesource.com` mirror for downloading mainline kernel sources, may be faster than `git.kernel.org` depending on your location
 - **USE_GITHUB_UBOOT_MIRROR** ( yes | **no** ): use unofficial Github mirror for downloading mainline U-Boot sources, may be faster than `git.denx.de` depending on your location


### PR DESCRIPTION
Add the option and description of DISABLE_IPV6 to modify the behavior of aria2c.  The default is how it has previously been done, with ipv6 disabled.  I don't know why it was done that way, so I made the minimum change necessary.