### PR TITLE
Revert "Add UBOOT_ONLY option doc"

### DIFF
--- a/docs/Developer-Guide_Build-Options.md
+++ b/docs/Developer-Guide_Build-Options.md
@@ -5,9 +5,6 @@ These parameters are meant to be applied to the `./compile.sh` command. They are
 ## Main options
 
 
-- **UBOOT_ONLY** (yes | **no** ):
-    - yes: compiles U-Boot only, implies KERNEL_ONLY=yes to make any default option validation happy
-    - no: no impact - build according to the subsequent options
 - **KERNEL_ONLY** ( yes | no ):
     - yes: compiles only kernel, U-Boot and other packages for installation on existing Armbian system
     - no: build complete OS image for writing to SD card


### PR DESCRIPTION
Reverts armbian/documentation#279

@EvilOlaf Please revert this merge, since based on the discussion on issue https://github.com/armbian/build/issues/4421 the appropriate script code pull request will not be merged. I will provide another pull request for a new `BUILD_ONLY` option on the build repo. When this has been accepted, I will create another pull request to the doc repo again.

I you mind, please have a look to https://github.com/armbian/build/issues/4421 for the details.
