### PR TITLE
Fix: Github emojis in markdown not rendered for the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ markdown_extensions:
       linenums: true
       use_pygments: true
   - pymdownx.superfences
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 nav:
   - Home: index.md

--- a/tools/mkArmbianDocs.py
+++ b/tools/mkArmbianDocs.py
@@ -135,6 +135,9 @@ markdown_extensions:
       linenums: true
       use_pygments: true
   - pymdownx.superfences
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 nav:
   - Home: index.md


### PR DESCRIPTION
 Add markdown extension pymdownx.emoji to mkdocs.yml.

## Test result
s. https://github.com/MHARMBIAN/armbian_documentation/releases/download/6b4720e/armbian-document-6b4720e.pdf

Chapter **5.5 Build Options**

![image](https://user-images.githubusercontent.com/45703410/207301570-fb5e03e4-05ef-4f7f-a982-28c8ca8b0409.png)

