### PR TITLE
Fix warnings on documentation release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,24 +65,19 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=timenow::$(date +'%Y-%m-%d')"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "timenow=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Rename release artifact
+        shell: bash
+        run: |
+          mv -v document.pdf armbian-document-${{ steps.vars.outputs.sha_short }}.pdf
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.vars.outputs.sha_short }}
-          release_name: ${{ steps.vars.outputs.timenow }}-${{ steps.vars.outputs.sha_short }}
+          tag: ${{ steps.vars.outputs.sha_short }}
+          name: ${{ steps.vars.outputs.timenow }}-${{ steps.vars.outputs.sha_short }}
           draft: false
           prerelease: false
-      - name: Upload PDF to releases
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: document.pdf
-          asset_name: armbian-document-${{ steps.vars.outputs.sha_short }}.pdf
-          asset_content_type: application/pdf
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: armbian-document-${{ steps.vars.outputs.sha_short }}.pdf
+          artifactContentType: application/pdf


### PR DESCRIPTION
## Issue
Current release workflow raises a couple of warnings:
![image](https://user-images.githubusercontent.com/45703410/207995044-381863ed-3a2a-4dd5-add5-b6a53246255c.png)

## Fix
This PR fixes the release workflow:
![image](https://user-images.githubusercontent.com/45703410/207995181-3adac345-05ad-4eb2-bad3-705c33b18ba3.png)

No warnings anymore:
![image](https://user-images.githubusercontent.com/45703410/207995281-8ea6e004-d20c-4e5e-90f3-1757eccdf1d1.png)
