### PR TITLE
Update docker install steps to align with updated docker docs

### DIFF
--- a/docs/User-Guide_Advanced-Features.md
+++ b/docs/User-Guide_Advanced-Features.md
@@ -68,11 +68,12 @@ This method is based on Docker Debian installation [documentation](https://docs.
 
 ```bash
 apt-get remove docker docker-engine docker.io containerd runc
-apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+apt-get install ca-certificates curl gnupg lsb-release
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt update
-apt-get install docker-ce docker-ce-cli containerd.io
+apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
 
 Test if Docker works correctly:

--- a/docs/User-Guide_Advanced-Features.md
+++ b/docs/User-Guide_Advanced-Features.md
@@ -56,7 +56,9 @@ Check which wireless stations / routers are in range
 
 ## How to run Docker?
 
-Docker works reliably with the distribution-provided builds of docker. It's as simple as `apt-get install docker.io`. If you prefer to use the latest docker builds provided directly by Docker. Please follow the guide below.
+Docker works reliably with the distribution-provided builds. It is as simple as `apt-get install docker.io`.  
+If you prefer to use the latest Docker builds provided directly by Docker, please follow the guide below.  
+Though if you run into trouble using those please revert back to distribution binaries before complaining.  
 
 Preinstallation requirements:
 


### PR DESCRIPTION
The current steps resulted in GPG key warnings/error on apt update. With the updated steps from the docker docs it worked.
Note: This adds docker-compose, as docker docs suggest this by default. Fee free to drop is you think this is not needed. 