### PR TITLE
Fix iso dead link for ubuntu server

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -4,7 +4,7 @@
 
 - x86/x64 machine running any OS; at least 4G RAM, SSD, quad core (recommended),
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or similar virtualization software **(highly recommended with a minimum of 25GB hard disk space for the virtual disk image)**
-- **The officially supported** compilation environment is [Ubuntu Jammy 22.04.x amd64](https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso) **only!**
+- **The officially supported** compilation environment is [Ubuntu Jammy 22.04.x amd64](https://www.releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso) **only!**
   - Ubuntu Focal can be used for building Bionic, Focal and Buster images as well, unsupported though
 - `binfmt_misc` kernel module (some *ubuntu-cloud* images do not have this module.  Switch to a generic kernel if that is the case.)
 - installed basic system, OpenSSH and Samba (optional)


### PR DESCRIPTION
I just replace the dead link with the link I found here https://www.releases.ubuntu.com/jammy/