### PR TITLE
testing the hook reveals it is called before `customize-image.sh` (proper sentence)

### DIFF
--- a/docs/Developer-Guide_Extensions-Hooks.md
+++ b/docs/Developer-Guide_Extensions-Hooks.md
@@ -105,7 +105,7 @@ access to the rootfs (`${SDCARD}`) in its pristine state after packages are inst
 
 > *run before customize-image.sh*
 
-This hook is called after `customize-image.sh` is called, but before the overlay is mounted. It thus can be used
+This hook is called before `customize-image.sh` is called and before the overlay is mounted. It thus can be used
 for the same purposes as `customize-image.sh`.
 
 Also known as (for backwards compatibility only):

--- a/docs/Developer-Guide_Extensions-Hooks.md
+++ b/docs/Developer-Guide_Extensions-Hooks.md
@@ -105,8 +105,8 @@ access to the rootfs (`${SDCARD}`) in its pristine state after packages are inst
 
 > *run before customize-image.sh*
 
-This hook is called before `customize-image.sh` is called and before the overlay is mounted. It thus can be used
-for the same purposes as `customize-image.sh`.
+This hook is called before `customize-image.sh` is executed and before the overlay is mounted. It thus can be used
+for the same purposes as `customize-image.sh` without the overlay.
 
 Also known as (for backwards compatibility only):
 


### PR DESCRIPTION
…oper english this time)

Mixed before and after in documentation of the hook. (if it can be used the same way as `customize-image.sh` will be tested tomorrow, i think if the image is not mounted, you cant do system settings)