### PR TITLE
Corrected latest change entry in Release_Changelog.md to use ISO 8601 date format.

### DIFF
--- a/docs/Release_Changelog.md
+++ b/docs/Release_Changelog.md
@@ -2,7 +2,7 @@
 
 * Note: If a new sub-version is released this does not necessarily mean all boards receive a new version number since most of the time these fixes are targeting a specific board or board family only.
 
-## v23.05.24 (2023-02-08)
+## v23.05.24 (2023-08-02)
 
 * Recreated images for: Banana M2S, Odroid C2, Khadas VIM3
 


### PR DESCRIPTION
I was confused when I looked at the changelog and saw the out-of-order dates, but I looked into the change described and realized it was simply using a YYYY-DD-MM date format instead of the ISO 8601 YYYY-MM-DD format used by the rest of the changelog.