### PR TITLE
Developer-Guide_Build-Options: Add warning about obsolescence

### DIFF
--- a/docs/Developer-Guide_Build-Options.md
+++ b/docs/Developer-Guide_Build-Options.md
@@ -1,3 +1,5 @@
+WARNING: DO NOT USE! Obsolete documentation, new documentation in progress..
+
 # Build options
 
 These parameters are meant to be applied to the `./compile.sh` command. They are **all** optional.  They can also be added to your [build configuration file](/Developer-Guide_Build-Preparation/#providing-build-configuration) to save time. Default values are marked **bold** if applicable. 


### PR DESCRIPTION
Most of these options do not work or have potential to break the system such as the CRYPTROOT -> Advice against using it until it's updated