### PR TITLE
Remove LIB_TAG

### DIFF
--- a/docs/Developer-Guide_Build-Options.md
+++ b/docs/Developer-Guide_Build-Options.md
@@ -64,9 +64,6 @@ These parameters are meant to be applied to the `./compile.sh` command. They are
 - **CREATE_PATCHES** ( yes | **no** ) :warning: **Warning:** This option is deprecated and may be removed in future releases - use the new `kernel-patch` / `uboot-patch` / `atf-patch` CLI commands instead.
     - yes: prompt right before the compilation starts to make changes to the source code for both U-Boot and kernel. From these changes patch files will be created and placed in `output` directory. If you want these patches included in a normal run (without CREATE_PATCHES to say) these files need to be copied to the appropriate directories. Also see [user provided patches](https://docs.armbian.com/Developer-Guide_User-Configurations/#user-provided-patches).
 - **BUILD_ALL** ( yes | no | demo ): cycle through all available board and kernel configurations and make images for all combinations  
-- **LIB_TAG** ( master | "branchname" ):
-    - set to `master` to compile from the master branch (default)
-    - set to another "branchname" to compile from any other branch available. Check [here](https://github.com/armbian/build/branches) for available branches  
 - **CARD_DEVICE** ( /dev/sdX ): set to the device of your SD card. The image will be burned and verified using Etcher for CLI.
 - **EXT=rkdevflash** to flash Rockchip images to eMMC either during image build or separately with flash CLI command ([only works bare Linux, not Docker](https://github.com/armbian/build/pull/5058))
 - **CRYPTROOT_ENABLE** ( yes | no ): enable LUKS encrypted rootfs


### PR DESCRIPTION
This apparently no longer supported - when using it I get:

```
[💥] error! [ LIB_TAG is set.This is not supported anymore. Please remove it, and manage the git branches manually.  ]
```