### PR TITLE
disable rockchip hw notes

### DIFF
--- a/docs/Hardware_Rockchip.md
+++ b/docs/Hardware_Rockchip.md
@@ -1,4 +1,4 @@
-# Rockchip RK3399 boards
+# Rockchip RK3399 boards (outdated)
 
 ## Graphics hardware acceleration (3D and VideoEngine)
 Both only work with legacy (4.4.y) kernel using Buster userspace.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
       - "H6": "Hardware_Allwinner-H6.md"
       - "Freescale i.MX6": "Hardware_Freescale-imx6.md"
       - "Marvell Armada": "Hardware_Marvell.md"
-      - "Rockchip": "Hardware_Rockchip.md"
+#      - "Rockchip": "Hardware_Rockchip.md"
 
   - "Developer Guide":
       - "Welcome": "Developer-Guide_Welcome.md"


### PR DESCRIPTION
They are outdated. 
Page commented until somebody steps up and adds some new stuff like for rk3588 or whatever...