### PR TITLE
Advanced_Features: fix building wifi driver guide

### DIFF
--- a/docs/User-Guide_Advanced-Features.md
+++ b/docs/User-Guide_Advanced-Features.md
@@ -22,9 +22,12 @@ Install and recreate kernel headers scripts (optional)
 Go back to root directory and fetch sources (working example, use `ARCH=arm64` on 64bit system)
 
 	cd
+    export KSRC="/usr/src/linux-headers-$(uname -r)"
 	git clone https://github.com/pvaret/rtl8192cu-fixes.git
 	cd rtl8192cu-fixes
-	make ARCH=arm
+	make -C "$KSRC" M="$PWD" ARCH=arm
+
+Refer to [Linux Kernel Documentations: Building External Modules](https://www.kernel.org/doc/html/latest/kbuild/modules.html) for more information.
 
 Load driver for test
 


### PR DESCRIPTION
Export kernel source directory a KSRC variable before building the driver and fix the building command to use $KSRC and M=$PWD to perform single kernel module build inside the out-of-tree kernel module directory.

Also add a reference link to official kbuild/modules documentations.