### PR TITLE
Lets generate webpage preview at PR

### DIFF
--- a/.github/workflows/pdf-at-pr.yaml
+++ b/.github/workflows/pdf-at-pr.yaml
@@ -17,22 +17,49 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: documentation
+
+      - uses: actions/checkout@v4
+        with:
+          ref: www
+          path: www
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
+          cd documentation
           python -m pip install --upgrade pip
           pip install setuptools wheel
           pip install -r requirements.txt
+
       - name: Run mkdocs --clean
         run: |
+
+          cd documentation
           mkdocs build --clean
 
-      - name: Upload pdf
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact
-          path: site/pdf/document.pdf
+      - name: Push to web
+        run: |
 
+          cd www
+          mkdir -p "${{ github.event.number }}"
+          rsync -av ../documentation/site/. ${{ github.event.number }}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add . 
+          git commit -m "Updating repo" || true
+          git push origin www || true
+
+      - uses: devindford/Append_PR_Comment@v1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          body-template: |
+
+            [![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
+            Documentation website preview will be available in few minutes:
+            <a href=https://armbian.github.io/documentation/${{ github.event.number }}><kbd> <br> Open WWW preview <br> </kbd></a>
+          body-update-action: 'suffix'


### PR DESCRIPTION
This expand GitHub action to generate HTML preview on the fly, at PR, available within 2-3min at:

`https://armbian.github.io/documentation/PR_NUMBER`

This below is automatically created:
<hr>

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/490><kbd> <br> Open WWW preview <br> </kbd></a>

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/490><kbd> <br> Open WWW preview <br> </kbd></a>