### PR TITLE
limit announcements for PRs

### DIFF
--- a/.github/workflows/pr-announce.yml
+++ b/.github/workflows/pr-announce.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     branches: [ master ]
+    types: [ opened ]
 
 jobs:
   build:


### PR DESCRIPTION
only send announcement when a PR is opened, nothing else.

untested

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/493><kbd> <br> Open WWW preview <br> </kbd></a>