### PR TITLE
Try to use dedicated secret

### DIFF
--- a/.github/workflows/pdf-at-pr.yaml
+++ b/.github/workflows/pdf-at-pr.yaml
@@ -50,13 +50,13 @@ jobs:
           rsync -av ../documentation/site/. ${{ github.event.number }}
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add . 
+          git add .
           git commit -m "Updating repo" || true
           git push origin www || true
 
       - uses: devindford/Append_PR_Comment@v1.1.3
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ secrets.PR_BODY_TEMPLATE }}"
           body-template: |
 
             [![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)


### PR DESCRIPTION


[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/500><kbd> <br> Open WWW preview <br> </kbd></a>