### PR TITLE
Improve build switches - part 1

### DIFF
--- a/docs/Developer-Guide_Build-Commands.md
+++ b/docs/Developer-Guide_Build-Commands.md
@@ -6,7 +6,16 @@ Builds kernel and device tree (where applicable) and places it to the `output/de
 
 Usage:
 ```bash
-./compile.sh kernel BOARD=nanopi-r5c BRANCH=edge 
+./compile.sh kernel BOARD=nanopi-r5c BRANCH=edge
+```
+
+### kernel-config
+
+Automatically call kernel's `make menuconfig` (add or remove modules or features)
+
+Usage:
+```bash
+./compile.sh kernel-config BOARD=nanopi-r5c BRANCH=edge
 ```
 
 ### dts-check


### PR DESCRIPTION
Moved half of switches from deprecated section up - which are operational. I propose to merge this - with quick sanity check. Its more or less attempt of better organisation.

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/521><kbd> <br> Open WWW preview <br> </kbd></a>