### PR TITLE
Add Monitoring section to the menu

### DIFF
--- a/.github/workflows/pull-from-armbian-config.yml
+++ b/.github/workflows/pull-from-armbian-config.yml
@@ -43,13 +43,14 @@ jobs:
           rsync -avr docs/System/System.user.md ../documentation/docs/User-Guide_Armbian-Config/System.md
 
           # the rest goes under armbian-software
-          mkdir -p ../documentation/docs/User-Guide_Armbian-Software/          
+          mkdir -p ../documentation/docs/User-Guide_Armbian-Software/
           #rsync -avr --exclude="Software.user.md" --exclude="Benchy.user.md" docs/Software/* ../documentation/docs/User-Guide_Armbian-Software/
 
           rsync -avr docs/Software/Containers.user.md ../documentation/docs/User-Guide_Armbian-Software/Containers.md
           rsync -avr docs/Software/Desktops.user.md ../documentation/docs/User-Guide_Armbian-Software/Desktops.md
           rsync -avr docs/Software/DevTools.user.md ../documentation/docs/User-Guide_Armbian-Software/DevTools.md
           rsync -avr docs/Software/HomeAutomation.user.md ../documentation/docs/User-Guide_Armbian-Software/HomeAutomation.md
+          rsync -avr docs/Software/Monitoring.user.md ../documentation/docs/User-Guide_Armbian-Software/Monitoring.md
           rsync -avr docs/Software/Management.user.md ../documentation/docs/User-Guide_Armbian-Software/Management.md
           rsync -avr docs/Software/Media.user.md ../documentation/docs/User-Guide_Armbian-Software/Media.md
           rsync -avr docs/Software/Netconfig.user.md ../documentation/docs/User-Guide_Armbian-Software/Netconfig.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
         - 'Containers': 'User-Guide_Armbian-Software/Containers.md'
         - 'Desktops': 'User-Guide_Armbian-Software/Desktops.md'
         - 'Home Automation': 'User-Guide_Armbian-Software/HomeAutomation.md'
+        - 'Monitoring': 'User-Guide_Armbian-Software/Monitoring.md'
         - 'DevTools': 'User-Guide_Armbian-Software/DevTools.md'
         - 'Management': 'User-Guide_Armbian-Software/Management.md'
         - 'Media': 'User-Guide_Armbian-Software/Media.md'


### PR DESCRIPTION
Depends on: https://github.com/armbian/configng/pull/237

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/526><kbd> <br> Open WWW preview <br> </kbd></a>