### PR TITLE
Remove WIREGUARD as its deprecated

### DIFF
--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -321,4 +321,3 @@ Automatically login as root for local consoles at first run. Disable if your sec
 	- leave empty to use default settings
 - **ROOT_FS_CREATE_ONLY** ( yes | **no** ): set to yes to force local cache creation
 - **EXTRAWIFI** ( **yes** | no ): include several drivers for [WiFi adapters](https://github.com/armbian/build/blob/1914066729b7d0f4ae4463bba2491e3ec37fac84/lib/compilation-prepare.sh#L179-L507)
-- **WIREGUARD** ( **yes** | no ): include Wireguard for kernels before it got upstreamed to mainline. Will lose functionality soon.


### PR DESCRIPTION
https://github.com/armbian/build/pull/7452

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/532><kbd> <br> Open WWW preview <br> </kbd></a>