### PR TITLE
Update gitignore for mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ site/
 venv/
 .venv/
 *.pdf
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to `gitignore` to ensure these files aren't synced

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/539><kbd> <br> Open WWW preview <br> </kbd></a>