### PR TITLE
remove etcher from recommendations

### DIFF
--- a/docs/User-Guide_Getting-Started.md
+++ b/docs/User-Guide_Getting-Started.md
@@ -112,7 +112,7 @@ graph LR
 
 **Important note:** Make sure you use a **good, reliable and fast** SD card. If you encounter boot or stability troubles in over 95 percent of the time it is either insufficient power supply or related to SD card (bad card, bad card reader, something went wrong when burning the image, card too slow to boot -- 'Class 10' highly recommended!). Armbian can simply not run on unreliable hardware so checking your SD card with either [F3](https://fight-flash-fraud.readthedocs.io/en/stable/) or [H2testw](https://www.heise.de/download/product/h2testw-50539) is mandatory if you run in problems. Since [counterfeit SD cards](https://www.happybison.com/reviews/how-to-check-and-spot-fake-micro-sd-card-8/) are still an issue checking with F3/H2testw directly after purchase is **highly recommended**.
 
-Write the **.xz compressed image** with a tool [USBImager](https://gitlab.com/bztsrc/usbimager) or [balenaEtcher](https://www.balena.io/etcher/) on all platforms since, unlike other tools, either can validate written data **saving you from corrupted SD card contents**.
+Write the **.xz compressed image** to your microSD card. Using [USBImager](https://gitlab.com/bztsrc/usbimager) on all platforms is recommended since, unlike other tools, it can validate written data **saving you from corrupted SD card contents**. Due to known issues using BalenaEtcher is not recommended at this time.
 
 !!! tip "Also important"
 


### PR DESCRIPTION
Etcher is known to be unreliable writing large images and has a spyware controversy attached to it. Therefore adjust recommendations.

[![Create offline documentation on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
Documentation website preview will be available in few minutes:
<a href=https://armbian.github.io/documentation/598><kbd> <br> Open WWW preview <br> </kbd></a>