### PR TITLE
docs(build): update link to build switches reference

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -65,7 +65,7 @@ Run framework:
 ## CLI
 
 
-Comprehensive list of build [Commands](../Developer-Guide_Build-Commands) and [Switches](Developer-Guide_Build-Switches.md)
+Comprehensive list of build [Commands](Developer-Guide_Build-Commands.md) and [Switches](Developer-Guide_Build-Switches.md)
 
 Example:
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -65,7 +65,7 @@ Run framework:
 ## CLI
 
 
-[Comprehensive list of build Options](Developer-Guide_Build-Switches.md)
+Comprehensive list of build [Commands](../Developer-Guide_Build-Commands) and [Switches](Developer-Guide_Build-Switches.md)
 
 Example:
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -65,7 +65,7 @@ Run framework:
 ## CLI
 
 
-[Comprehensive list of build Options](Developer-Guide_Build-Options.md)
+[Comprehensive list of build Options](Developer-Guide_Build-Switches.md)
 
 Example:
 


### PR DESCRIPTION
Hello! In the documentation about the [Build Framework](https://docs.armbian.com/Developer-Guide_Overview/), specifically in the Getting Started section, [the paragraph dedicated to build options contains a broken link](https://docs.armbian.com/Developer-Guide_Build-Preparation/#cli): 404 not found.

<img width="1013" src="https://github.com/user-attachments/assets/d5a0f217-b27b-44df-9d6b-3579dd9c0665" />


I thought it would be appropriate to update it with the link dedicated to build options, as indicated in https://docs.armbian.com/Developer-Guide_Build-Switches/

I wanted to bring this oversight to your attention, thank you.