### PR TITLE
docs: Use deb822 APT source for armbian-config

### DIFF
--- a/docs/User-Guide_Armbian-Config.md
+++ b/docs/User-Guide_Armbian-Config.md
@@ -39,9 +39,13 @@ In theory it should work on any systemd APT based Linux distributions such as: L
 ~~~
 wget -qO - https://apt.armbian.com/armbian.key | gpg --dearmor | \
 sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] \
-https://github.armbian.com/configng stable main" | \
-sudo tee /etc/apt/sources.list.d/armbian-config.list > /dev/null
+cat << EOF | sudo tee /etc/apt/sources.list.d/armbian-config.sources > /dev/null
+Types: deb
+URIs: https://github.armbian.com/configng
+Suites: stable
+Components: main
+Signed-By: /usr/share/keyrings/armbian.gpg
+EOF
 sudo apt update
 sudo apt -y install armbian-config
 ~~~


### PR DESCRIPTION
Replace creation of `armbian-config.list` with `armbian-config.sources`. This holds the same information in a newer format, deb822. APT has supported this format since version 1.1, released in 2015.

This does not affect `armbian.list`.

See also:

- https://github.com/armbian/configng/pull/407
- https://github.com/armbian/build/pull/7782