### PR TITLE
feat: Use deb822 APT sources

### DIFF
--- a/docs/User-Guide_Fine-Tuning.md
+++ b/docs/User-Guide_Fine-Tuning.md
@@ -197,7 +197,7 @@ Assure `jq` is installed
 Get a list of available mirrors from our `https://apt.armbian.com/mirrors` endpoint.
 
 ```bash
-curl -s http://apt.armbian.com/mirrors|jq
+curl -s http://apt.armbian.com/mirrors | jq
 ```
 
 You will see a result set similar to this, listing mirrors by region:
@@ -230,4 +230,4 @@ You will see a result set similar to this, listing mirrors by region:
 }
 ```
 
-Edit `/etc/apt/sources.list.d/armbian.list` and replace the url `http://apt.armbian.com` with your preferred mirror.
+Edit `/etc/apt/sources.list.d/armbian.sources` and replace the URL `https://apt.armbian.com` with your preferred mirror.


### PR DESCRIPTION
> This PR and the related PRs will require discussion or RFC before merging, particularly around handling migration of existing installations.

See main PR: https://github.com/armbian/build/pull/7790

- Replace `armbian.list` with `armbian.sources`. This holds the same information in a newer format, deb822.
- Replace HTTP with HTTPS for Armbian repositories.