### PR TITLE
deprecate lib.config

### DIFF
--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -11,7 +11,7 @@ Patches with the same file name and path in the `userpatches` directory tree ove
 
 ## User provided configuration
 
-A configuration file named `userpatches/config-<something>.conf.sh` (`.conf` also allowed) is a bash script that is sourced during the build if `./compile.sh something` is issued. All parameters which normally are passed via command line can be used (`PARAM1=value1` `PARAM2=value`) by using the same syntax, one separate line per `PARAM`. Command-line parameters still can override what is the config file. More advanced use cases can use conditionals, define functions to implement hooks, source other/common config files, etc. A few, quite complex, examples can be found in https://github.com/lanefu/armbian-userpatches-example-indiedroid-nova
+A configuration file named `userpatches/config-<something>.conf.sh` (`.conf` also allowed) is a bash script that is sourced during the build if `./compile.sh something` is issued. All parameters which normally are passed via command line can be used (`PARAM1=value1` `PARAM2=value`) by using the same syntax, one separate line per `PARAM`. Command-line parameters still can override what is the config file. More advanced use cases can use conditionals, define functions to implement hooks, source other/common config files, etc. A few, quite complex, examples can be found [here](https://github.com/lanefu/armbian-userpatches-example-indiedroid-nova).
 
 ## Legacy user provided configuration (deprecated, support for this will be removed at some point)
 

--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -11,6 +11,10 @@ Patches with the same file name and path in the `userpatches` directory tree ove
 
 ## User provided configuration
 
+A configuration file named `userpatches/config-<something>.conf.sh` (`.conf` also allowed) is a bash script that is sourced during the build if `./compile.sh something` is issued. All parameters which normally are passed via command line can be used (`PARAM1=value1` `PARAM2=value`) by using the same syntax, one separate line per `PARAM`. Command-line parameters still can override what is the config file. More advanced use cases can use conditionals, define functions to implement hooks, source other/common config files, etc. A few, quite complex, examples can be found in https://github.com/lanefu/armbian-userpatches-example-indiedroid-nova
+
+## Legacy user provided configuration (deprecated, support for this will be removed at some point)
+
 If the file `userpatches/lib.config` exists, it will be called and can override the particular kernel and u-boot versions. It can also add additional packages to be installed, by adding to `PACKAGE_LIST_ADDITIONAL`. For a comprehensive list of available variables, look through  `lib/functions/configuration/main-config.sh`. Some examples of what you can change:
 
     PACKAGE_LIST_ADDITIONAL="$PACKAGE_LIST_ADDITIONAL python-serial python" # additional packages


### PR DESCRIPTION
Text (mostly) from Ricardo from here: https://github.com/armbian/documentation/pull/344#discussion_r1242686073

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/678"><kbd><br> Open WWW preview <br></kbd></a>