### PR TITLE
add redirect for https://docs.armbian.com/User-Guide_Allwinner_overlays/

### DIFF
--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -297,7 +297,7 @@ Enforce building from source instead of using pre-built artifacts.
 - `yes`
 - `no`  (default)
 
-Enforce building without Armbian repository. Suitable for developing new releases or making custom images that doesn't need Armbian repository.
+Enforce building without Armbian repository. Suitable for developing new releases or making custom images that don't need Armbian repository.
 
 **SECTOR_SIZE** ( `value` )
 - `512` (default, for SD/EMMC/...)

--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -11,7 +11,7 @@ Patches with the same file name and path in the `userpatches` directory tree ove
 
 ## User provided configuration
 
-A configuration file named `userpatches/config-<something>.conf.sh` (`.conf` also allowed) is a bash script that is sourced during the build if `./compile.sh something` is issued. All parameters which normally are passed via command line can be used (`PARAM1=value1` `PARAM2=value`) by using the same syntax, one separate line per `PARAM`. Command-line parameters still can override what is the config file. More advanced use cases can use conditionals, define functions to implement hooks, source other/common config files, etc. A few, quite complex, examples can be found [here](https://github.com/lanefu/armbian-userpatches-example-indiedroid-nova).
+A configuration file named `userpatches/config-<something>.conf.sh` (`.conf` also allowed) is a bash script that is sourced during the build if `./compile.sh something` is issued. All parameters which normally are passed via command line can be used (`PARAM1=value1` `PARAM2=value`) by using the same syntax, one separate line per `PARAM`. Command-line parameters still can override what is in the config file. More advanced use cases can use conditionals, define functions to implement hooks, source other/common config files, etc. A few, quite complex, examples can be found [here](https://github.com/lanefu/armbian-userpatches-example-indiedroid-nova).
 
 ## Legacy user provided configuration (deprecated, support for this will be removed at some point)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,9 @@ extra:
 
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+        'User-Guide_Allwinner_overlays.md': 'User-Guide_Armbian_overlays.md'
 #   - with-pdf:
 #       author: Armbian documentation team
 #       copyright: © 2024 by Armbian

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Jinja2~=3.1.4
 markdown>=3.6
 mkdocs>=1.6.0
 mkdocs-material>=9.5.31
+mkdocs-redirects>=1.2.2
 mkdocs-with-pdf>=0.9.3
 mdx_truly_sane_lists>=1.3.0
 weasyprint==44


### PR DESCRIPTION
https://docs.armbian.com/User-Guide_Allwinner_overlays/ is referenced /boot/dtb/overlay/README.sun4i-a10-overlays and others.  It should redirect to https://docs.armbian.com/User-Guide_Armbian_overlays/ nowadays.

Including other small, cosmetic fixes in the PR.