### PR TITLE
fix staging anchor in "board suppport rules"

### DIFF
--- a/docs/User-Guide_Board-Support-Rules.md
+++ b/docs/User-Guide_Board-Support-Rules.md
@@ -10,7 +10,7 @@ Support definitions, criteria and relationships for:
 - [Platinum Support](#platinum-support)
 - [Standard support](#standard-support)
 - [Community maintained](#community-maintained)
-- [Staging](#)
+- [Staging](#staging)
 
 ## Platinum Support
 


### PR DESCRIPTION
the HTML anchor for the "Staging" heading isn't there, this PR fixes that