### PR TITLE
Overriding $TERM to a more compatible value like xterm-256color

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -69,13 +69,14 @@ Run framework:
 ```
 
 !!! tip "Troubleshooting: 'unknown terminal type' error"
-When running the script, especially from modern terminal emulators (like Ghostty, Kitty, WezTerm), you might encounter an error like 'xterm-ghostty': unknown terminal type
+    When running the script, especially from modern terminal emulators (like Ghostty, Kitty, WezTerm), you might encounter an error like
 
-**Quick Workaround:** You can force a more common terminal type before running the script:
-```bash
-export TERM=xterm-256color
-./compile.sh
-```
+    'xterm-ghostty': unknown terminal type
+
+    **Quick workaround:** you can force a more common terminal type before running the script:
+    ```bash
+    env TERM=xterm-256color ./compile.sh
+    ```
 
 Only one command can be specified.
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -68,6 +68,15 @@ Run framework:
 ./compile.sh [command] [switch...] [config...]
 ```
 
+!!! tip "Troubleshooting: 'unknown terminal type' error"
+When running the script, especially from modern terminal emulators (like Ghostty, Kitty, WezTerm), you might encounter an error like 'xterm-ghostty': unknown terminal type
+
+**Quick Workaround:** You can force a more common terminal type before running the script:
+```bash
+export TERM=xterm-256color
+./compile.sh
+```
+
 Only one command can be specified.
 
 Switches are parameter settings that are used by the build framework itself


### PR DESCRIPTION
Hello everyone! I ran into a small compatibility issue when using the interactive UI. I’m using the Ghostty terminal emulator, and in this case the build process failed with a fatal error:

`'xterm-ghostty': unknown terminal type.`

I think this simple issue can affect users of modern terminal emulators such as Ghostty, Kitty, etc... 

These terminals often set a TERM environment variable (e.g., xterm-ghostty, xterm-kitty) that is not included in the default terminfo database available inside the build environment. As a result, text‑based user interface (TUI) tools like dialog cannot render.

I think it is enough to just add a small note in the documentation, as indicated in the commit.