### PR TITLE
Improve documentation header - adding more info, change current

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,13 +5,37 @@
   <a href="https://www.armbian.com">
     <span class="twemoji twitter">
       {% include ".icons/fontawesome/solid/house.svg" %}
-    </span> &nbsp; www.armbian.com
+    </span> &nbsp; Home
   </a>
   &nbsp;
-  <a href="https://github.com/sponsors/armbian">
+  <a href="https://www.armbian.com/download">
+    <span class="twemoji twitter">
+      {% include ".icons/fontawesome/solid/download.svg" %}
+    </span> &nbsp; Download
+  </a>
+  &nbsp;
+  <a href="https://blog.armbian.com">
+    <span class="twemoji twitter">
+      {% include ".icons/fontawesome/solid/newspaper.svg" %}
+    </span> &nbsp; Newsletter
+  </a>
+  &nbsp;
+  <a href="https://forum.armbian.com">
+    <span class="twemoji twitter">
+      {% include ".icons/fontawesome/solid/user-group.svg" %}
+    </span> &nbsp; Forum
+  </a>
+  &nbsp;
+  <a href="https://github.com/armbian">
+    <span class="twemoji twitter">
+      {% include ".icons/fontawesome/brands/github.svg" %}
+    </span> &nbsp; GitHub / Source code
+  </a>
+  &nbsp;
+  <a href="https://www.armbian.com/donate">
     <span class="twemoji twitter">
       {% include ".icons/fontawesome/solid/heart.svg" %}
-    </span> &nbsp; Support Armbian!
+    </span> &nbsp; Donate
   </a>
   <a rel="me" href="https://fosstodon.org/@armbian"></a>
 {% endblock %}


### PR DESCRIPTION
Before 

<img width="742" height="44" alt="image" src="https://github.com/user-attachments/assets/e24b5b91-4179-41ab-b0fb-d338fbac1300" />

After:

<img width="742" height="44" alt="image" src="https://github.com/user-attachments/assets/a0ee50ff-16ef-4be9-9b59-f2b8cc955ccb" />
