### PR TITLE
docs: add extensions reference list

### DIFF
--- a/docs/Developer-Guide_Extension-ccache-remote.md
+++ b/docs/Developer-Guide_Extension-ccache-remote.md
@@ -1,0 +1,257 @@
+# Extension: ccache-remote
+
+[ccache](https://ccache.dev/) significantly speeds up repeated kernel and
+U-Boot builds by caching compiled objects. By default, each build host has
+its own local cache. This extension adds a **shared remote cache** so that
+multiple build machines (or a CI server and a developer workstation) can all
+benefit from objects already compiled by someone else.
+
+Typical scenarios:
+
+- A home lab with several SBCs used as build hosts — first build populates
+  the cache, subsequent builds on other machines hit it.
+- A CI server and developer laptops sharing one cache server so that a
+  developer rarely needs to compile from scratch after CI has run.
+- A single machine where the local cache was lost (disk wiped) but the
+  remote cache is still warm.
+
+The extension supports two backends:
+
+- **Redis** — lower latency, recommended for fast local networks. Cache lives
+  entirely in RAM on the server, so capacity is limited by available memory.
+- **HTTP/WebDAV** (nginx) — somewhat slower, but stores cache on disk. Can
+  be orders of magnitude larger than a RAM-backed Redis instance, making it
+  a better choice when cache size matters more than speed.
+
+### Auto-discovery vs. explicit configuration
+
+The simplest deployment uses **Avahi (DNS-SD)**. Once the cache server is
+set up and publishing its service, and Avahi is installed on all build hosts,
+enabling the extension is all that is needed — no URL configuration required.
+
+If Avahi is not available or not desirable, the server URL must be provided
+explicitly via `CCACHE_REMOTE_STORAGE`, or for remote servers via
+`CCACHE_REMOTE_DOMAIN` (DNS SRV). See [Parameters](#parameters) below.
+
+The extension automatically enables `USE_CCACHE=yes` and handles all ccache
+configuration including Docker pass-through.
+
+## Quick start
+
+If a cache server is already running on the local network and advertising
+itself via DNS-SD (Avahi), no configuration is needed:
+
+```bash
+./compile.sh BOARD=<board> BRANCH=<branch> ENABLE_EXTENSIONS="ccache-remote"
+```
+
+With an explicit Redis server:
+
+```bash
+./compile.sh BOARD=<board> BRANCH=<branch> \
+  ENABLE_EXTENSIONS="ccache-remote" \
+  CCACHE_REMOTE_STORAGE="redis://192.168.1.65:6379"
+```
+
+With an explicit HTTP/WebDAV server:
+
+```bash
+./compile.sh BOARD=<board> BRANCH=<branch> \
+  ENABLE_EXTENSIONS="ccache-remote" \
+  CCACHE_REMOTE_STORAGE="http://192.168.1.65:8088/ccache/"
+```
+
+To enable permanently from a userconfig file:
+
+```bash
+enable_extension "ccache-remote"
+# optionally:
+# CCACHE_REMOTE_STORAGE="redis://192.168.1.65:6379"
+```
+
+## Requirements
+
+- **ccache**: version 4.4 or newer (for remote storage support).
+- **Redis backend**: Redis server accessible from the build host.
+- **HTTP backend**: nginx with WebDAV module (`nginx-extras`).
+- **Auto-discovery**: `avahi-browse` (package `avahi-utils`) on the build host.
+
+## Parameters
+
+| Variable | Default | Description |
+|---|---|---|
+| **`CCACHE_REMOTE_STORAGE`** | _(empty)_ | Remote storage URL. If not set, auto-discovery is attempted. |
+| **`CCACHE_REMOTE_DOMAIN`** | _(empty)_ | Domain for DNS SRV discovery (e.g. `example.com`). |
+| **`CCACHE_REMOTE_ONLY`** | `no` | Set to `yes` to disable local cache and use only remote storage (saves local disk space). |
+| **`CCACHE_REDIS_CONNECT_TIMEOUT`** | `500` | Redis connection timeout in milliseconds. |
+| **`CCACHE_READONLY`** | _(empty)_ | Set to any value to use cache read-only (don't write new entries). |
+| **`CCACHE_RECACHE`** | _(empty)_ | Recompile everything and update cache (bypass existing entries). |
+| **`CCACHE_RESHARE`** | _(empty)_ | Push existing local cache entries to remote storage. |
+| **`CCACHE_MAXSIZE`** | _(empty)_ | Maximum local cache size (e.g. `10G`). |
+| **`CCACHE_NAMESPACE`** | _(empty)_ | Namespace for cache isolation between projects or branches. |
+| **`CCACHE_DISABLE`** | _(empty)_ | Set to any value to disable ccache completely. |
+
+For the full list of supported variables see the `CCACHE_PASSTHROUGH_VARS`
+array in the extension source or the
+[ccache configuration reference](https://ccache.dev/manual/latest.html#config_remote_storage).
+
+### CCACHE_REMOTE_STORAGE URL format
+
+```
+Redis:  redis://[[USER:]PASSWORD@]HOST[:PORT][|attribute=value...]
+HTTP:   http://HOST[:PORT]/PATH/[|attribute=value...]
+```
+
+Common attributes:
+
+| Attribute | Default | Description |
+|---|---|---|
+| `connect-timeout` | `100` ms | Connection timeout. Increase on slow networks. |
+| `operation-timeout` | `10000` ms | Per-operation timeout. |
+
+Examples:
+
+```
+redis://192.168.1.65:6379|connect-timeout=500
+redis://default:secretpass@192.168.1.65:6379|connect-timeout=500
+http://192.168.1.65:8088/ccache/
+```
+
+!!! warning
+    Redis passwords must not contain `/`, `+`, `=`, or spaces — these break
+    URL parsing. Generate a safe password with:
+    ```bash
+    openssl rand -hex 24
+    ```
+
+## Server discovery
+
+When `CCACHE_REMOTE_STORAGE` is not set, the extension tries to discover a
+cache server automatically in this order:
+
+1. **DNS-SD** (mDNS / Avahi): browse for `_ccache._tcp` on the local network.
+   Requires `avahi-browse` on the build host and the cache server publishing
+   a DNS-SD service. Redis is preferred over HTTP when both are found.
+
+2. **DNS SRV**: query `_ccache._tcp.DOMAIN` when `CCACHE_REMOTE_DOMAIN` is
+   set. Useful for remote or cloud-hosted build servers.
+
+3. **Legacy mDNS**: resolve the hostname `ccache.local` (falls back to Redis
+   on port 6379). Kept for backward compatibility.
+
+If none of these succeeds, the extension silently falls back to local cache only.
+
+## Cache sharing requirements
+
+For the cache to be shared across multiple build hosts, **the Armbian source
+tree must be at the same path on all machines** (e.g. `/home/build/armbian`).
+ccache includes the working directory in the cache key, so different paths
+produce different keys and the cache will not be shared.
+
+Docker builds are not affected — they always use a consistent internal path.
+
+## Server setup
+
+### Redis (recommended)
+
+1. Install:
+
+    ```bash
+    apt install redis-server avahi-daemon avahi-utils
+    ```
+
+2. Configure Redis — copy `misc/redis/redis-ccache.conf` from the extension
+   directory and include it in `/etc/redis/redis.conf`:
+
+    ```bash
+    echo "include /etc/redis/redis-ccache.conf" >> /etc/redis/redis.conf
+    systemctl restart redis-server
+    ```
+
+3. Set a password (recommended for any non-isolated network):
+
+    ```bash
+    openssl rand -hex 24   # use output as password
+    # set requirepass <password> in redis-ccache.conf
+    ```
+
+4. Publish the DNS-SD service so clients discover it automatically:
+
+    ```bash
+    # Static (always advertise):
+    cp misc/avahi/ccache-redis.service /etc/avahi/services/
+
+    # Or tied to redis-server lifecycle:
+    cp misc/systemd/ccache-avahi-redis.service /etc/systemd/system/
+    systemctl enable --now ccache-avahi-redis
+    ```
+
+### HTTP/WebDAV (nginx)
+
+1. Install:
+
+    ```bash
+    apt install nginx-extras avahi-daemon avahi-utils
+    ```
+
+2. Enable the WebDAV site:
+
+    ```bash
+    cp misc/nginx/ccache-webdav.conf /etc/nginx/sites-available/ccache-webdav
+    ln -s /etc/nginx/sites-available/ccache-webdav /etc/nginx/sites-enabled/
+    mkdir -p /var/cache/ccache-webdav/ccache
+    chown -R www-data:www-data /var/cache/ccache-webdav
+    systemctl reload nginx
+    ```
+
+3. Verify:
+
+    ```bash
+    curl -X PUT -d "test" http://localhost:8088/ccache/test.txt
+    curl http://localhost:8088/ccache/test.txt
+    ```
+
+    !!! warning
+        The provided nginx configuration has no authentication. Use only on a
+        trusted private network.
+
+4. Publish the DNS-SD service:
+
+    ```bash
+    cp misc/avahi/ccache-webdav.service /etc/avahi/services/
+    ```
+
+### DNS SRV records (remote servers)
+
+For build hosts that cannot reach the cache server via mDNS, set
+`CCACHE_REMOTE_DOMAIN` and create DNS records:
+
+Redis backend:
+```text
+_ccache._tcp.example.com.  SRV  0 0 6379 ccache.example.com.
+_ccache._tcp.example.com.  TXT  "type=redis"
+```
+
+HTTP/WebDAV backend:
+```text
+_ccache._tcp.example.com.  SRV  0 0 8088 ccache.example.com.
+_ccache._tcp.example.com.  TXT  "type=http" "path=/ccache/"
+```
+
+### mDNS client requirements
+
+For `.local` hostname resolution to work on the build host:
+
+```bash
+# Option A: systemd-resolved
+apt install libnss-resolve
+
+# Option B: standalone
+apt install libnss-mdns
+```
+
+## References
+
+- [ccache remote storage documentation](https://ccache.dev/manual/latest.html#config_remote_storage)
+- [ccache Redis how-to](https://ccache.dev/howto/redis-storage.html)
+- [ccache HTTP how-to](https://ccache.dev/howto/http-storage.html)

--- a/docs/Developer-Guide_Extension-kernel-rust.md
+++ b/docs/Developer-Guide_Extension-kernel-rust.md
@@ -1,0 +1,118 @@
+# Extension: kernel-rust
+
+The Linux kernel has been gaining Rust support since version 6.1, with more
+subsystems and drivers being written in Rust alongside traditional C code.
+In the near future, practically useful drivers and subsystems for Armbian users
+are expected to require or benefit from Rust kernel support. Enabling
+`CONFIG_RUST` in the kernel build unlocks this capability.
+
+Without this extension, Armbian kernels are built without Rust support —
+the toolchain is not installed and `CONFIG_RUST` does not appear in
+menuconfig. This extension installs a pinned Rust toolchain via `rustup`,
+enables `CONFIG_RUST` automatically, and configures all required build
+parameters so that Rust kernel modules can be compiled alongside C code.
+The toolchain versions and other aspects of the build can be adjusted via
+[parameters](#parameters) passed to the build system.
+
+## Why rustup instead of distro packages
+
+Distribution-provided Rust packages currently cannot fully satisfy all the
+requirements for enabling Rust in a recent kernel. Mixing some components
+from the distro with others from external sources is fragile and not
+worthwhile. For this reason the extension downloads a complete, version-pinned
+toolchain via `rustup` independently of the host distro.
+
+When the base distro used by the Armbian build system provides packages
+sufficient to build the Rust environment for the latest kernels entirely from
+distro sources, Armbian will likely switch to using them.
+
+## Quick start
+
+```bash
+./compile.sh BOARD=<board> BRANCH=<branch> ENABLE_EXTENSIONS="kernel-rust"
+```
+
+To open menuconfig with Rust options visible:
+
+```bash
+./compile.sh kernel-config BOARD=<board> BRANCH=<branch> ENABLE_EXTENSIONS="kernel-rust"
+```
+
+To enable permanently from a userconfig file:
+
+```bash
+enable_extension "kernel-rust"
+```
+
+## Requirements
+
+- **Kernel version**: 6.12 or newer. The minimum required rustc version depends on the kernel release; see the [Rust-for-Linux version policy](https://rust-for-linux.com/rust-version-policy).
+- **Host package**: `libclang-dev` — installed automatically by the extension.
+- **Build host architecture**: x86_64, aarch64, or riscv64.
+- Internet access on first use (downloads rustup-init and toolchain components).
+
+## Parameters
+
+| Variable | Default | Description |
+|---|---|---|
+| **`RUST_VERSION`** | `1.85.0` | rustc version installed via rustup. |
+| **`BINDGEN_VERSION`** | `0.71.1` | `bindgen-cli` version installed via cargo. |
+| **`RUST_KERNEL_SAMPLES`** | `no` | Set to `yes` to build sample Rust kernel modules (`rust_minimal`, `rust_print`, `rust_driver_faux`) as loadable modules. Useful for smoke-testing the toolchain. |
+| **`RUST_EXTRA_COMPONENTS`** | _(empty array)_ | Additional rustup components to install (e.g. `clippy`, `llvm-tools`). |
+| **`RUST_EXTRA_CARGO_CRATES`** | _(empty array)_ | Additional cargo crates to install. Supports `name` or `name@version` syntax. |
+
+## Toolchain cache
+
+The toolchain is installed once into `${SRC}/cache/tools/rustup/` and reused
+across builds. The cache is content-addressed by a hash of:
+
+- `RUST_VERSION`
+- `BINDGEN_VERSION`
+- build host architecture
+- `RUST_EXTRA_COMPONENTS`
+- `RUST_EXTRA_CARGO_CRATES`
+
+Changing any of these values invalidates the cache and triggers a full reinstall
+on the next build. The marker file is `.marker-<hash>` inside the cache directory.
+
+## Extensibility
+
+Other extensions can request additional toolchain components or crates before
+the toolchain is installed:
+
+```bash
+# In your extension file:
+RUST_EXTRA_COMPONENTS+=("clippy" "llvm-tools")
+RUST_EXTRA_CARGO_CRATES+=("mdbook" "cargo-deb@2.11.0")
+```
+
+## Kernel artifact versioning
+
+The extension adds a short hash of `RUST_VERSION|BINDGEN_VERSION` to the kernel
+artifact version string (key `_R`, e.g. `rust1a2b`). This ensures that changing
+toolchain versions triggers a kernel rebuild even if the kernel source is
+unchanged.
+
+## Implementation notes
+
+### env -i isolation
+
+The kernel build runs under `env -i`, which clears the entire environment.
+The extension passes Rust tool paths directly as make parameters
+(`RUSTC=`, `RUSTFMT=`, `BINDGEN=`) and sets `RUST_LIB_SRC` via the make
+environment array. Direct paths into the toolchain sysroot are used instead
+of rustup proxy binaries, so `RUSTUP_HOME` does not need to be in the
+cleared environment.
+
+### ccache and Rust
+
+ccache does not support rustc (upstream won't-fix since 2019). The kernel
+build system has no `RUSTC_WRAPPER` mechanism, so Rust compilation is not
+cached by ccache. Only C/assembly compilation benefits from ccache when this
+extension is active.
+
+## References
+
+- [Rust in the Linux kernel — quick start](https://docs.kernel.org/rust/quick-start.html)
+- [Rust for Linux — version policy](https://rust-for-linux.com/rust-version-policy)
+- [rustup installation](https://rust-lang.github.io/rustup/installation/index.html)

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -78,6 +78,8 @@ Adds a C++ compiler to host build dependencies. The C++ compiler is no longer in
 
 Enables ccache with a remote storage backend (Redis or HTTP/WebDAV) for sharing the compilation cache across multiple build hosts. Requires ccache 4.4+.
 
+See: [ccache-remote extension](Developer-Guide_Extension-ccache-remote.md)
+
 ---
 
 ## cleanup-space-final-image

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -68,6 +68,12 @@ Sets up Bluetooth via `hciattach` for boards that require serial attachment.
 
 ---
 
+## brostrend-aic8800-dkms
+
+Installs the AIC8800 WiFi/BT DKMS driver for BroStrend USB adapters. Fetches the latest `aic8800-dkms` release from `Shadowrom2020/aic8800-dkms` GitHub and builds the kernel module in the chroot. Forces `INSTALL_HEADERS=yes` — requires a kernel with working headers package.
+
+---
+
 ## c-plus-plus-compiler
 
 Adds a C++ compiler to host build dependencies. The C++ compiler is no longer included by default; enable this extension when the build requires it.
@@ -136,6 +142,12 @@ Adds XFS filesystem support. Auto-enabled when `ROOTFS_TYPE=xfs`.
 
 ---
 
+## gateway-dk-ask
+
+NXP ASK (Application Solutions Kit) integration for the Mono Gateway Development Kit (LS1046A). Builds ASK kernel modules (CDX, FCI, auto-bridge, sfp-led, lp5812) in-tree with the kernel and packages userspace tools (`fmlib`, `fmc`, `libfci`, `libcli`, `dpa-app`, `cmm`) plus patched system libraries and configs into a single `.deb`. Requires iptables at runtime.
+
+---
+
 ## gen-sample-extension-docs
 
 Generates extension hook documentation and a sample extension file. Useful for extension developers.
@@ -144,13 +156,13 @@ Generates extension hook documentation and a sample extension file. Useful for e
 
 ## grub
 
-Standard GRUB bootloader setup for UEFI-capable boards. Supports `DISTRO_GENERIC_KERNEL` mode.
+Standard GRUB bootloader setup for UEFI-capable boards. Supports `DISTRO_GENERIC_KERNEL` mode (uses distro kernel instead of Armbian's). Sets `GRUB_GFXPAYLOAD_LINUX=text` to keep the framebuffer console bound to `fbcon` (prevents a black local console after Plymouth quits on CLI installs), passes `splash plymouth.ignore-serial-consoles` so kernel boot messages remain visible while Plymouth draws the splash on the framebuffer. Deliberately omits `quiet` and `loglevel=3`, and disables Ubuntu's `vt.handoff=7` injection.
 
 ---
 
 ## grub-riscv64
 
-GRUB bootloader setup for RISC-V 64-bit boards.
+GRUB bootloader setup for RISC-V 64-bit boards. Mirrors the console/splash cmdline conventions of the `grub` extension.
 
 ---
 
@@ -169,6 +181,12 @@ Builds the `gxlimg` tool used for creating Amlogic bootable images.
 ## image-output-abl
 
 Converts the output image to ABL (Android Boot Loader) format using `mkbootimg`.
+
+---
+
+## image-output-arduino
+
+Converts the Armbian image into a QDL-flashable archive for Arduino UNO Q (Qualcomm QRB2210). Fetches Qualcomm flash binaries during image creation.
 
 ---
 
@@ -216,7 +234,7 @@ Adds USB Mass Storage (UMS) gadget support to the initramfs, allowing the board 
 
 ## jethub-burn
 
-Adds JetHub device flashing support to the build.
+Automatically converts the Armbian `.img` into a JetHub burn image after the main build.
 
 ---
 
@@ -320,6 +338,12 @@ Applies preset first-run configuration specific to the Odin2 gaming device.
 
 ---
 
+## photonicat-pm
+
+Installs the `photonicat-pm` DKMS power-management driver for the Ariaboard Photonicat router. Fetches the latest release from `HackingGate/photonicat-pm` GitHub and builds the kernel module in chroot. Skipped on kernels ≥ 6.20. Requires working kernel headers.
+
+---
+
 ## preset-firstrun
 
 Applies preset network and first-run configuration to the image (writes `.not_logged_in_yet`).
@@ -365,6 +389,12 @@ Installs Texas Instruments packages from the official TI Debian package reposito
 ## u-boot-menu
 
 Configures the U-Boot boot menu for boards that support it.
+
+---
+
+## uboot-binman-fix-pkg-resources
+
+Patches U-Boot's `binman` tool to use `importlib.resources` instead of `pkg_resources`, restoring build compatibility on hosts with `setuptools >= 82` (which removed `pkg_resources`). Covers U-Boot v2024.x–v2025.04.
 
 ---
 

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -1,0 +1,429 @@
+# Extensions Reference
+
+Alphabetical reference of all official Armbian build framework extensions.
+Extensions live in the `extensions/` directory of the build repository.
+
+To enable one or more extensions:
+
+```bash
+./compile.sh BOARD=... BRANCH=... ENABLE_EXTENSIONS="ext-name,another-ext"
+```
+
+Extensions with dedicated documentation pages are linked below.
+All others are documented by a short description and key parameters.
+
+---
+
+## allwinner-kernel-bump
+
+Bumps the kernel version for Allwinner-based boards.
+
+---
+
+## amlogic-fip-blobs
+
+Fetches Amlogic FIP (Firmware Image Package) blobs needed for bootloader assembly on Amlogic SoCs.
+
+---
+
+## apa
+
+Enables Armbian Package Archive (APA) in the target image by default.
+
+---
+
+## arm64-compat-vdso
+
+Enables 32-bit compat vDSO for arm64 kernels. Requires a 32-bit ARM cross-compiler for GCC builds (`gcc-arm-linux-gnueabi` or custom `CROSS_COMPILE_COMPAT`). For clang builds uses the built-in LLVM backend.
+
+---
+
+## armbian-config
+
+Installs `armbian-config` from the Armbian GitHub repository into the image.
+
+---
+
+## armbian-live-patch
+
+Installs the Armbian Live Patch systemd service into the BSP package.
+
+---
+
+## bcmdhd
+
+Builds the Broadcom BCM WiFi (`bcmdhd`) driver as a DKMS kernel module. Requires working kernel headers.
+
+---
+
+## bcmdhd-spacemit
+
+Builds the Broadcom BCM WiFi driver for SpacemiT platforms as a DKMS kernel module.
+
+---
+
+## bluetooth-hciattach
+
+Sets up Bluetooth via `hciattach` for boards that require serial attachment.
+
+---
+
+## c-plus-plus-compiler
+
+Adds a C++ compiler to host build dependencies. The C++ compiler is no longer included by default; enable this extension when the build requires it.
+
+---
+
+## ccache-remote
+
+Enables ccache with a remote storage backend (Redis or HTTP/WebDAV) for sharing the compilation cache across multiple build hosts. Requires ccache 4.4+.
+
+---
+
+## cleanup-space-final-image
+
+Runs `zerofree` and cleans APT caches in the final image to reduce disk footprint.
+
+---
+
+## cloud-init
+
+Installs and configures cloud-init in the target image.
+
+---
+
+## detect-unused-extensions
+
+Developer/testing extension: a hook honeypot used to verify the extension framework works correctly.
+
+---
+
+## fake-vcgencmd
+
+Installs a fake `vcgencmd` stub for Raspberry Pi software compatibility on non-Pi boards.
+
+---
+
+## fs-btrfs-support
+
+Adds Btrfs filesystem support: host build tools and image packages. Auto-enabled when `ROOTFS_TYPE=btrfs`.
+
+---
+
+## fs-cryptroot-support
+
+Adds LUKS/cryptroot support. Auto-enabled when `CRYPTROOT_ENABLE=yes`.
+
+---
+
+## fs-f2fs-support
+
+Adds F2FS filesystem support. Auto-enabled when `ROOTFS_TYPE=f2fs`.
+
+---
+
+## fs-nilfs2-support
+
+Adds NILFS2 filesystem support. Auto-enabled when `ROOTFS_TYPE=nilfs2`.
+
+---
+
+## fs-xfs-support
+
+Adds XFS filesystem support. Auto-enabled when `ROOTFS_TYPE=xfs`.
+
+---
+
+## gen-sample-extension-docs
+
+Generates extension hook documentation and a sample extension file. Useful for extension developers.
+
+---
+
+## grub
+
+Standard GRUB bootloader setup for UEFI-capable boards. Supports `DISTRO_GENERIC_KERNEL` mode.
+
+---
+
+## grub-riscv64
+
+GRUB bootloader setup for RISC-V 64-bit boards.
+
+---
+
+## grub-with-dtb
+
+GRUB with device tree blob (DTB) embedding support.
+
+---
+
+## gxlimg
+
+Builds the `gxlimg` tool used for creating Amlogic bootable images.
+
+---
+
+## image-output-abl
+
+Converts the output image to ABL (Android Boot Loader) format using `mkbootimg`.
+
+---
+
+## image-output-oowow
+
+Creates an image compatible with the OOWOW recovery system for Khadas boards.
+
+---
+
+## image-output-ovf
+
+Produces an OVF (Open Virtualization Format) archive for use in VMware and other hypervisors. Depends on `image-output-qcow2`.
+
+---
+
+## image-output-qcow2
+
+Produces a qcow2 image suitable for QEMU/KVM virtualization.
+
+---
+
+## image-output-utm
+
+Produces a UTM-compatible image for macOS virtualization. Depends on `image-output-qcow2`.
+
+---
+
+## image-output-vhd-azure
+
+Produces a VHD image for use with Microsoft Azure.
+
+---
+
+## image-output-vhdx
+
+Produces a VHDX image. Depends on `image-output-qcow2`.
+
+---
+
+## initramfs-usb-gadget-ums
+
+Adds USB Mass Storage (UMS) gadget support to the initramfs, allowing the board to expose its storage over USB.
+
+---
+
+## jethub-burn
+
+Adds JetHub device flashing support to the build.
+
+---
+
+## kernel-rust
+
+Enables Rust language support in the Linux kernel (`CONFIG_RUST`). Installs a rustup-managed toolchain into `${SRC}/cache/tools/rustup/` and configures all required make parameters.
+
+---
+
+## kernel-version-toolchain
+
+Adds the compiler name and version (e.g. `gcc13.3`, `clang20.1`) to the kernel artifact version string, ensuring cache invalidation when the toolchain changes.
+
+**Variables:** none (auto-detects from `KERNEL_COMPILER`).
+
+---
+
+## lowmem
+
+Applies Armbian optimizations for low-memory boards (reduced parallelism, swap configuration, etc.).
+
+---
+
+## lsmod
+
+Applies `localmodconfig` based on an lsmod output file to build a minimal kernel. Place the lsmod file in `userpatches/lsmod/<board>.lsmod`. **Variable:** `LSMOD` (defaults to `$BOARD`).
+
+---
+
+## lvm
+
+Adds LVM (Logical Volume Manager) support to the image.
+
+---
+
+## marvell-tools
+
+Fetches Marvell Armada A3700 build tools, DDR library, and binary blobs needed for bootloader assembly.
+
+---
+
+## mesa-vpu
+
+Installs Mesa 3D and VPU/Chromium acceleration packages. On Ubuntu: full 3D + 4K VPU. On Debian: 3D only.
+
+---
+
+## mtkflash
+
+Adds MediaTek device flashing tool support to the build.
+
+---
+
+## net-chrony
+
+Installs the `chrony` NTP daemon for network time synchronization.
+
+---
+
+## net-network-manager
+
+Installs NetworkManager and Netplan for network interface management.
+
+---
+
+## net-systemd-networkd
+
+Installs systemd-networkd and Netplan for network interface management.
+
+---
+
+## net-systemd-timesyncd
+
+Installs `systemd-timesyncd` for network time synchronization.
+
+---
+
+## nicod-armbian-gaming
+
+Gaming-oriented Armbian image configuration.
+
+---
+
+## nomod
+
+Builds the kernel with all modules disabled (`localmodconfig` with empty lsmod). Produces a non-working kernel — intended for rapid kernel build/packaging tests only.
+
+---
+
+## nvidia
+
+Builds the Nvidia proprietary kernel module via DKMS. Not available in minimal images.
+
+---
+
+## odin2-preset-firstrun
+
+Applies preset first-run configuration specific to the Odin2 gaming device.
+
+---
+
+## preset-firstrun
+
+Applies preset network and first-run configuration to the image (writes `.not_logged_in_yet`).
+
+---
+
+## radxa-aic8800
+
+Builds the Radxa AIC8800 WiFi driver as a DKMS kernel module. Requires working kernel headers.
+
+---
+
+## rkbin-tools
+
+Fetches Rockchip binary tools (`rkbin`) from the configured git repository. **Variables:** `RKBIN_GIT_URL`, `RKBIN_GIT_BRANCH`.
+
+---
+
+## rkdevflash
+
+Adds Rockchip device flashing tool support to the build.
+
+---
+
+## sunxi-tools
+
+Adds a 32-bit ARM cross-compiler to host dependencies for Allwinner (sunxi) builds. Only required outside Docker.
+
+---
+
+## syterkit-allwinner
+
+Writes the SyterKit bootloader image to the appropriate offset in the Allwinner output image.
+
+---
+
+## ti-debpkgs
+
+Installs Texas Instruments packages from the official TI Debian package repository.
+
+---
+
+## u-boot-menu
+
+Configures the U-Boot boot menu for boards that support it.
+
+---
+
+## uboot-btrfs
+
+Enables Btrfs filesystem support in U-Boot (`CONFIG_CMD_BTRFS`).
+
+---
+
+## uefi-edk2-rk3588
+
+Integrates UEFI EDK2 firmware for Rockchip RK3588 boards.
+
+---
+
+## ufs
+
+Creates a UFS-sector-aligned image. Requires Debian Trixie (13) or newer as the build host. Set `DOCKER_ARMBIAN_BASE_IMAGE=debian:trixie` when building in Docker.
+
+---
+
+## uwe5622-allwinner
+
+Builds the UWE5622 WiFi driver for Allwinner-based boards.
+
+---
+
+## v4l2loopback-dkms
+
+Builds the `v4l2loopback` virtual camera kernel module via DKMS. Not available in minimal images.
+
+---
+
+## vmware-vm
+
+Creates a VMware-compatible image (VMDK + OVF) with VMware tools installed. Depends on `image-output-ovf`.
+
+---
+
+## wayland-sessions-mask
+
+Masks Wayland desktop session entries for boards with limited or unstable Wayland support.
+
+---
+
+## watchdog
+
+Installs the `watchdog` daemon and enables `CONFIG_WATCHDOG` / hardware watchdog device support in the kernel.
+
+---
+
+## xorg-lima-serverflags
+
+Configures X.Org server flags for the Lima open-source GPU driver.
+
+---
+
+## yt6801
+
+Builds the Motorcomm YT6801 Ethernet controller driver as a DKMS kernel module. Requires working kernel headers.
+
+---
+
+## zfs
+
+Builds ZFS kernel module and userspace tools via DKMS. Requires working kernel headers.

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -222,6 +222,8 @@ Adds JetHub device flashing support to the build.
 
 Enables Rust language support in the Linux kernel (`CONFIG_RUST`). Installs a rustup-managed toolchain into `${SRC}/cache/tools/rustup/` and configures all required make parameters.
 
+See: [kernel-rust extension](Developer-Guide_Extension-kernel-rust.md)
+
 ---
 
 ## kernel-version-toolchain

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
         - 'Extensions Framework' : 'Developer-Guide_Extensions.md'
         - 'Extensions List' : 'Developer-Guide_Extensions-List.md'
         - 'Extension: kernel-rust' : 'Developer-Guide_Extension-kernel-rust.md'
+        - 'Extension: ccache-remote' : 'Developer-Guide_Extension-ccache-remote.md'
         - 'Desktops' : 'Developer-Guide_Desktops.md'
 
   - 'ARMBIAN COMMUNITY' :

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
         - 'Building with Docker' : 'Developer-Guide_Building-with-Docker.md'
         - 'Extensions Framework' : 'Developer-Guide_Extensions.md'
         - 'Extensions List' : 'Developer-Guide_Extensions-List.md'
+        - 'Extension: kernel-rust' : 'Developer-Guide_Extension-kernel-rust.md'
         - 'Desktops' : 'Developer-Guide_Desktops.md'
 
   - 'ARMBIAN COMMUNITY' :

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,7 +150,7 @@ nav:
         - 'Media': 'User-Guide_Armbian-Software/Media.md'
         - 'Monitoring': 'User-Guide_Armbian-Software/Monitoring.md'
         - 'Music': 'User-Guide_Armbian-Software/Music.md'
-        - 'Netconfig': 'User-Guide_Armbian-Software/Netconfig.md'        
+        - 'Netconfig': 'User-Guide_Armbian-Software/Netconfig.md'
         - 'Printing': 'User-Guide_Armbian-Software/Printing.md'
         - 'VPN': 'User-Guide_Armbian-Software/VPN.md'
         - 'Web hosting': 'User-Guide_Armbian-Software/WebHosting.md'
@@ -164,7 +164,8 @@ nav:
         - 'Extensions Hooks' : 'Developer-Guide_Extensions-Hooks.md'
         - 'Building with Multipass' : 'Developer-Guide_Building-with-Multipass.md'
         - 'Building with Docker' : 'Developer-Guide_Building-with-Docker.md'
-        - 'Extensions' : 'Developer-Guide_Extensions.md'
+        - 'Extensions Framework' : 'Developer-Guide_Extensions.md'
+        - 'Extensions List' : 'Developer-Guide_Extensions-List.md'
         - 'Desktops' : 'Developer-Guide_Desktops.md'
 
   - 'ARMBIAN COMMUNITY' :


### PR DESCRIPTION
## Summary

- Add `Developer-Guide_Extensions-List.md`: alphabetical reference of all 60+ official Armbian build extensions, each with a short description
- Add `Developer-Guide_Extension-kernel-rust.md`: dedicated page for the kernel-rust extension with full documentation
- Add `Developer-Guide_Extension-ccache-remote.md`: dedicated page for the ccache-remote extension — overview, backend comparison (Redis vs WebDAV), auto-discovery via Avahi vs explicit configuration, quick start, parameters, server setup guides
- Rename nav entry `Extensions` → `Extensions Framework` to better reflect that page's content (framework concepts and writing guide, not a catalog)
- Fix trailing whitespace on one nav entry

## Keeping the extensions list up to date

The list is maintained manually with the help of Claude Code (AI assistant).
To refresh it after extensions are added or changed in `armbian/build`, open
a Claude Code session in the `armbian-doc` repository and use the following prompt:

> I need to update `docs/Developer-Guide_Extensions-List.md` to reflect the
> current state of extensions in `armbian/build` (`extensions/` directory).
> Please:
> 1. Compare the current list with all `.sh` files in `extensions/` (including
>    subdirectories).
> 2. For any new extensions — add an entry with a description and all
>    externally configurable variables (those set with `:-` defaults or
>    declared as `declare -g`).
> 3. For changed extensions — update the description and parameters if needed.
> 4. Do not change entries for extensions that have not changed.
> 5. Keep the alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)