### PR TITLE
Update theme colors and fonts to match armbian.com

### DIFF
--- a/docs/css/armbian-extra.css
+++ b/docs/css/armbian-extra.css
@@ -1,3 +1,20 @@
+/* Armbian brand colors matching armbian.com */
+:root {
+  --md-primary-fg-color: #F26522;
+  --md-primary-fg-color--light: #FF8B1A;
+  --md-primary-fg-color--dark: #DC5819;
+  --md-accent-fg-color: #F26522;
+  --md-accent-fg-color--transparent: #F2652218;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #F26522;
+  --md-primary-fg-color--light: #FF8B1A;
+  --md-primary-fg-color--dark: #DC5819;
+  --md-accent-fg-color: #F26522;
+  --md-accent-fg-color--transparent: #F2652218;
+}
+
 .md-typeset__table {
    min-width: 100%;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,16 +14,19 @@ theme:
     logo: images/armbian-logo.png
     icon:
       repo: fontawesome/brands/github-alt
+    font:
+        text: DM Sans
+        code: JetBrains Mono
     palette:
         - scheme: default
-          primary: red
-          accent: red
+          primary: custom
+          accent: custom
           toggle:
             icon: material/toggle-switch-off-outline
             name: Switch to dark mode
         - scheme: slate
-          primary: red
-          accent: red
+          primary: custom
+          accent: custom
           toggle:
             icon: material/toggle-switch
             name: Switch to light mode


### PR DESCRIPTION
## Summary
- Switch primary/accent color from red to Armbian orange (`#F26522`)
- Use DM Sans (body) and JetBrains Mono (code) fonts to match the new website
- Applied to both light and dark mode schemes

## Test plan
- [x] Verify colors render correctly in light mode
- [x] Verify colors render correctly in dark mode
- [x] Check font loading works

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/902"><kbd><br> Open WWW preview <br></kbd></a>