### PR TITLE
copyright: match website footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Armbian Documentation
 site_author: "Armbian team"
 site_url: https://docs.armbian.com
 site_description: Official documentation for Armbian OS and Armbian build framework
-copyright: Copyright &copy; 2013 - 2024 Armbian.com
+copyright: &copy; 2026 Armbian. Open source Linux for ARM boards.
 repo_url: https://github.com/armbian/documentation
 edit_uri: edit/main/docs/
 repo_name: armbian/documentation


### PR DESCRIPTION
Docs footer was `Copyright © 2013 - 2024 Armbian.com`, out of sync with the main site footer which reads `© 2026 Armbian. Open source Linux for ARM boards.`. Align the MkDocs `copyright:` line to match.