### PR TITLE
Build-Switches: document DOCKER_PRUNE opt-in

### DIFF
--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -137,6 +137,19 @@ Enables automatic background updates of Docker build images via a system cronjob
     - `/etc/cron.d/armbian-docker-pull` - cronjob (runs at 00:00 and 12:00)
     - `/var/lib/armbian/docker-pull.hash` - configuration hash for update detection
 
+**DOCKER_PRUNE** ( `string` )
+
+- `yes`: prune old Armbian build images from the local Docker daemon at the start of each build
+- `no` (default): leave existing images in place
+
+Whether the build framework automatically reclaims disk space by removing old Armbian build images during setup. Off by default — safe for hosts where multiple build invocations share one Docker daemon (typical for a server running several self-hosted GitHub Actions runners on the same machine), since concurrent pruning can race with another invocation that is still committing a freshly built image and surface as `failed to get digest sha256:…: no such file or directory`, aborting the in-flight build.
+
+Set to `yes` on single-host setups where automatic disk reclaim is desirable.
+
+!!! warning "Behaviour change"
+
+    Earlier releases ran the cleanup unconditionally. The default is now `no`; users who relied on the automatic reclaim need to set `DOCKER_PRUNE=yes` explicitly.
+
 - **CI** ( `string` )
   - true
   - **false**


### PR DESCRIPTION
## Summary

armbian/build PR [#9704](https://github.com/armbian/build/pull/9704) gates the Docker image cleanup behind `DOCKER_PRUNE=yes` (default off) to avoid a race on hosts where multiple build invocations share one Docker daemon. This PR documents the new switch in `Developer-Guide_Build-Switches.md` next to the existing `DOCKER_*` entries, with a behaviour-change note for users who relied on the previous automatic reclaim.

Requested by @tabrisnet during review of armbian/build#9704.

## Test plan

- [x] Render the docs locally and confirm the new section renders correctly between `ARMBIAN_DOCKER_AUTO_PULL` and `CI`.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/920"><kbd><br> Open WWW preview <br></kbd></a>