### PR TITLE
docs: document PREFER_NATIVE_ARMHF and enrich arm64-compat-vdso entry

### DIFF
--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -334,6 +334,34 @@ Build and bundle [stubble](https://github.com/ubuntu/stubble), Canonical's EFI s
 
 The result is a single signed UKI that EFI-boots and picks the correct device tree for the running board automatically — intended for generic UEFI-on-devicetree images. It is enabled by default for the `uefidt` family (board `uefi-arm64-dt`) and is opt-in elsewhere; boards that boot through U-Boot do not use it. Requires `ukify` (from systemd) with `--devicetree-auto` support on the build host.
 
+<a id="prefer_native_armhf"></a>
+**PREFER_NATIVE_ARMHF** ( `string` )
+
+- `yes` (default)
+- `no`
+
+On arm64 build hosts whose kernel supports `CONFIG_COMPAT`, run armhf binaries (rootfs/chroot, package post-install) natively at full speed instead of through `qemu-user-static`. Native execution is roughly 10× faster than qemu emulation. On hosts without 32-bit ARM userspace support (notably Apple Silicon) the framework transparently falls back to qemu. Set `no` to force qemu even when native COMPAT is available.
+
+To build an arm64 Armbian kernel that exposes this capability for the host that runs it, enable the [arm64-compat-vdso extension](Developer-Guide_Extensions-List.md#arm64-compat-vdso) via `ENABLE_EXTENSIONS`. The relevant kernel options are documented in the [arm64 Kconfig](https://elixir.bootlin.com/linux/latest/source/arch/arm64/Kconfig):
+
+- `CONFIG_COMPAT=y` — required; enables 32-bit EL0 support, without which armhf binaries cannot run at all.
+- `CONFIG_COMPAT_VDSO=y` — optional but recommended; provides fast `gettimeofday`/`clock_gettime` for 32-bit processes via vDSO.
+
+To check what a given host kernel ships with:
+
+```bash
+zcat /proc/config.gz | grep -E '^CONFIG_(COMPAT|COMPAT_VDSO)='
+```
+
+A host with native armhf support will print at least `CONFIG_COMPAT=y`; for example:
+
+```bash
+CONFIG_COMPAT=y
+CONFIG_COMPAT_VDSO=y
+```
+
+If the command prints nothing, or `CONFIG_COMPAT` is unset, the host kernel cannot run armhf userspace natively and the build framework will use qemu emulation regardless of this switch.
+
 **ARTIFACT_IGNORE_CACHE** ( `string` )
 
 - `yes`

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -34,7 +34,11 @@ Enables Armbian Package Archive (APA) in the target image by default.
 
 ## arm64-compat-vdso
 
-Enables 32-bit compat vDSO for arm64 kernels. Requires a 32-bit ARM cross-compiler for GCC builds (`gcc-arm-linux-gnueabi` or custom `CROSS_COMPILE_COMPAT`). For clang builds uses the built-in LLVM backend.
+Builds the arm64 kernel with `CONFIG_COMPAT`, `CONFIG_COMPAT_VDSO` and `CONFIG_ARM64_32BIT_EL0`, letting a host running this kernel execute armhf (32-bit ARM) userspace natively at full speed. One concrete benefit is faster Armbian builds: on such a host, armhf rootfs / chroot / package post-install steps run native instead of through `qemu-user-static` (~10× faster). The build framework auto-detects the capability — see [PREFER_NATIVE_ARMHF](Developer-Guide_Build-Switches.md#prefer_native_armhf).
+
+Requires a 32-bit ARM cross-compiler for GCC builds (`gcc-arm-linux-gnueabi` or custom `CROSS_COMPILE_COMPAT`). For clang builds uses the built-in LLVM backend.
+
+Limitation: aarch64 silicon without 32-bit ARM userspace support at EL0 (notably Apple M-series) cannot run armhf even with this kernel option enabled.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the new `PREFER_NATIVE_ARMHF` build switch landed in armbian/build#9820 and enriches the existing `arm64-compat-vdso` entry in the Extensions reference so the two cross-link sensibly.

- **Developer-Guide_Build-Switches.md** — new `PREFER_NATIVE_ARMHF` entry (default `yes`, opt-out `no`). Explains when it kicks in (arm64 host with `CONFIG_COMPAT`), what it changes (rootfs/chroot/post-install armhf steps run native instead of qemu, ~10× faster), and how to inspect the host kernel (`zcat /proc/config.gz | grep ...`) with sample output. Cross-links the [arm64-compat-vdso extension](https://github.com/armbian/documentation/blob/main/docs/Developer-Guide_Extensions-List.md#arm64-compat-vdso) and the [arm64 Kconfig](https://elixir.bootlin.com/linux/latest/source/arch/arm64/Kconfig).
- **Developer-Guide_Extensions-List.md** — replaces the one-liner for `arm64-compat-vdso` with a description of the practical effect (native armhf userspace via `CONFIG_COMPAT` / `CONFIG_COMPAT_VDSO` / `CONFIG_ARM64_32BIT_EL0`), the build-time benefit, and the Apple-M-series limitation. Cross-links the switch.

## Test plan

- [x] MkDocs build (`mkdocs build --strict`) — both cross-links resolve, no broken anchors introduced by this PR. (The only remaining `--strict` abort is the pre-existing `docs/README.md`/`index.md` collision, unrelated to this change and fixed by armbian/documentation#933.)
- [x] Visual check: `PREFER_NATIVE_ARMHF` ↔ `#arm64-compat-vdso` round-trip resolves in both directions.