### PR TITLE
Add rewrite-kernel-config command to Build commands

### DIFF
--- a/docs/Developer-Guide_Build-Commands.md
+++ b/docs/Developer-Guide_Build-Commands.md
@@ -18,6 +18,15 @@ Usage:
 ./compile.sh kernel-config BOARD=nanopi-r5c BRANCH=edge
 ```
 
+### rewrite-kernel-config
+
+Automatically validates kernel config changes and dependency chains. After manually editing the config for a given family and branch this is needed to ensure the config change will persist our CI.
+
+Usage:
+```bash
+./compile.sh rewrite-kernel-config BOARD=xxxxx BRANCH=current
+```
+
 ### dts-check
 
 Validate dts files and improve board & patch development overall.


### PR DESCRIPTION
Added 'rewrite-kernel-config' command to validate kernel config changes and ensure persistence in CI.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/922"><kbd><br> Open WWW preview <br></kbd></a>