### PR TITLE
`Automatic` wireless performance results

### DIFF
--- a/docs/WifiPerformance.md
+++ b/docs/WifiPerformance.md
@@ -61,76 +61,77 @@ All wireless adapters were tested under consistent conditions - each positioned 
 
 ## WiFi performance
 
-_Measured 2026-07-01 06:33 UTC · [run](https://github.com/armbian/autotests/actions/runs/28497549738)_
+_Measured 2026-07-01 11:47 UTC_
 
-**47** wireless link(s) · ✅ **47** pass · 📶 peak ↑ **756** / ↓ **643** Mbps
+**48** wireless link(s) · ✅ **48** pass · 📶 peak ↑ **681** / ↓ **868** Mbps
 
 #### IEEE 802.11ac
 
 | Board | Status | Attach | Chip | Channel | ↑ Up (Mbps) | ↓ Down (Mbps) |
 |:--|:--:|:--|:--|:--|--:|--:|
-| Banana Pi CM4IO | ✅ | SDIO | Realtek RTL8822CS | 5240 MHz @ 80 | 43 | 36 |
-| Banana Pi CM4IO | ✅ | USB | Realtek RTL8821CU | 2437 MHz @ 20 | 43 | 43 |
-| Banana Pi M2Pro | ✅ | USB | Realtek RTL8821CU | 2437 MHz @ 20 | 36 | 43 |
-| BananaPi BPI-F3 | ✅ | USB | Realtek RTL8822BU | 5240 MHz @ 80 | 264 | 170 |
-| Helios4 | ✅ | USB | Realtek RTL8821CU | 5240 MHz @ 80 | 202 | 242 |
-| Khadas VIM1 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 18 | 11 |
-| Khadas VIM2 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 100 | 89 |
-| Khadas VIM3 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 17 | 35 |
-| NanoPi M4V2 | ✅ | SDIO | Broadcom BCM4356 | 5240 MHz @ 40 | 175 | 78 |
-| NanoPi M4V2 | ✅ | USB | MediaTek MT7610 | 5240 MHz @ 80 | 148 | 222 |
-| NanoPi M5 | ✅ | SDIO | Realtek RTL8822CS | 2437 MHz @ 20 | 17 | 59 |
-| Orange Pi 3 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 47 | 102 |
-| Orange Pi Lite 2 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 41 | 32 |
-| Orange Pi Zero2 | ✅ | — | Unisoc UWE5622 |  | 31 | 38 |
-| OrangePi 3 LTS | ✅ | — | Unisoc (unisoc_wifi) |  | 140 | 137 |
-| Pine H64 | ✅ | USB | Realtek RTL8812AU | 5240 MHz @ 80 | 219 | 88 |
-| Raspberry Pi | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 221 | 227 |
-| Rockpi E | ✅ | USB | Realtek RTL8821CU | 2437 MHz @ 20 | 32 | 41 |
-| Tanix TX6 | ✅ | SDIO | Realtek RTL8822CS | 2437 MHz @ 20 | 45 | 60 |
-| UEFI x86 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 23 | 21 |
+| Banana Pi CM4IO | ✅ | SDIO | Realtek RTL8822CS | 2437 MHz @ 20 | 15 | 28 |
+| Banana Pi CM4IO | ✅ | USB | Realtek RTL8821CU | 2437 MHz @ 20 | 45 | 36 |
+| Banana Pi M2Pro | ✅ | USB | Realtek RTL8821CU | 2437 MHz @ 20 | 28 | 43 |
+| BananaPi BPI-F3 | ✅ | USB | Realtek RTL8822BU | 5240 MHz @ 80 | 265 | 132 |
+| Helios4 | ✅ | USB | Realtek RTL8821CU | 5240 MHz @ 80 | 259 | 241 |
+| Khadas VIM1 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 6 | 22 |
+| Khadas VIM2 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 105 | 97 |
+| Khadas VIM3 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 39 | 42 |
+| NanoPi M4V2 | ✅ | SDIO | Broadcom BCM4356 | 5240 MHz @ 40 | 122 | 209 |
+| NanoPi M4V2 | ✅ | USB | MediaTek MT7610 | 5240 MHz @ 80 | 131 | 245 |
+| NanoPi M5 | ✅ | SDIO | Realtek RTL8822CS | 5240 MHz @ 80 | 44 | 88 |
+| Orange Pi 3 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 19 | 108 |
+| Orange Pi Lite 2 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 29 | 37 |
+| Orange Pi Zero2 | ✅ | — | Unisoc UWE5622 | — | 132 | 93 |
+| OrangePi 3 LTS | ✅ | — | Unisoc (unisoc_wifi) | — | 44 | 22 |
+| Pine H64 | ✅ | USB | Realtek RTL8812AU | 5240 MHz @ 80 | 200 | 271 |
+| Raspberry Pi | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 80 | 247 | 182 |
+| Tanix TX6 | ✅ | SDIO | Realtek RTL8822CS | 5240 MHz @ 80 | 119 | 103 |
+| UEFI x86 | ✅ | SDIO | Broadcom (brcmfmac) | 5240 MHz @ 40 | 25 | 22 |
 
 #### IEEE 802.11ax
 
 | Board | Status | Attach | Chip | Channel | ↑ Up (Mbps) | ↓ Down (Mbps) |
 |:--|:--:|:--|:--|:--|--:|--:|
-| BananaPi BPI-F3 | ✅ | SDIO | Realtek RTL8852BS | 5240 MHz @ 80 | 312 | 377 |
-| Orange Pi 5 Plus | ✅ | USB | MediaTek MT7921 | 5240 MHz @ 80 | 663 | 335 |
-| Rock 5B | ✅ | PCIe | Realtek RTL8852BE | 5240 MHz @ 80 | 580 | 585 |
-| Rock 5T | ✅ | PCIe | Realtek RTL8852BE | 5240 MHz @ 80 | 362 | 504 |
+| BananaPi BPI-F3 | ✅ | SDIO | Realtek RTL8852BS | 5240 MHz @ 80 | 352 | 394 |
+| Orange Pi 5 Plus | ✅ | USB | MediaTek MT7921 | 5240 MHz @ 80 | 646 | 350 |
+| Rock 5B | ✅ | PCIe | Realtek RTL8852BE | 5240 MHz @ 80 | 199 | 609 |
+| Rock 5T | ✅ | PCIe | Realtek RTL8852BE | 5240 MHz @ 80 | 348 | 450 |
+| Tinker Board 2 | ✅ | PCIe | Realtek RTL8852AE | 5240 MHz @ 80 | 332 | 416 |
 
 #### IEEE 802.11be
 
 | Board | Status | Attach | Chip | Channel | ↑ Up (Mbps) | ↓ Down (Mbps) |
 |:--|:--:|:--|:--|:--|--:|--:|
-| Orange Pi 5 Plus | ✅ | PCIe | Qualcomm WCN7851 | 5240 MHz @ 160 | 53 | 42 |
-| Rock 5B Plus | ✅ | PCIe | MediaTek MT7925 | 6215 MHz @ 160 | 756 | 643 |
-| Tinker Board 2 | ✅ | PCIe | Realtek RTL8852AE | 5240 MHz @ 80 | 355 | 354 |
+| Orange Pi 5 Plus | ✅ | PCIe | Qualcomm WCN7851 | 5240 MHz @ 160 | 232 | 784 |
+| Rock 5B Plus | ✅ | PCIe | MediaTek MT7925 | 6215 MHz @ 160 | 681 | 868 |
 
 #### IEEE 802.11n
 
 | Board | Status | Attach | Chip | Channel | ↑ Up (Mbps) | ↓ Down (Mbps) |
 |:--|:--:|:--|:--|:--|--:|--:|
-| Banana Pi M2 Ultra | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 35 | 41 |
-| Banana Pi M5 | ✅ | USB | Realtek RTL8192CU | 2437 MHz @ 20 | 29 | 31 |
-| Banana Pi Pro | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 17 | 21 |
-| Cubietruck | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 20 | 30 |
-| Inovato Quadra | ✅ | SDIO | XRadio XR819 | 2437 MHz @ 20 | 13 | 13 |
-| NanoPi Duo | ✅ | USB | Realtek RTL8188EUS 802.11n | 2437 MHz @ 20 | 9 | 32 |
-| NanoPi K2 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 15 | 31 |
-| NanoPi R1 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 11 | 24 |
-| NanoPi R4S | ✅ | USB | Ralink RT5370 | 2437 MHz @ 20 | 39 | 21 |
-| Odroid C4 | ✅ | USB | Ralink RT5572 | 5240 MHz @ 40 | 115 | 86 |
-| Orange Pi R1 | ✅ | SDIO | Realtek RTL8189ES |  | 36 | 34 |
-| Orange Pi R1 | ✅ | SDIO | Realtek RTL8189ES |  | 8 | 16 |
-| Orange Pi Zero | ✅ | USB | MediaTek MT7601 | 2437 MHz @ 20 | 11 | 19 |
-| Orange Pi Zero Plus | ✅ | SDIO | Realtek RTL8189FS |  | 40 | 16 |
-| Orange Pi Zero Plus | ✅ | SDIO | Realtek RTL8189FS |  | 24 | 31 |
-| Raspberry Pi | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 14 | 31 |
-| Rock 5B Plus | ✅ | USB | Realtek RTL8723BU 802.11b/g/n | 2437 MHz @ 20 | 39 | 33 |
-| Rock 5T | ✅ | USB | Ralink RT5572 | 5240 MHz @ 40 | 94 | 92 |
-| Tanix TX6 | ✅ | USB | Ralink RT2870/RT3070 | 2437 MHz @ 20 | 38 | 8 |
-| Tinker Board | ✅ | SDIO | Realtek RTL8723BS | 2437 MHz @ 20 | 40 | 37 |
+| Banana Pi M2 Ultra | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 33 | 44 |
+| Banana Pi M5 | ✅ | USB | Realtek RTL8192CU | 2437 MHz @ 20 | 37 | 27 |
+| Banana Pi Pro | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 16 | 19 |
+| Cubietruck | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 14 | 21 |
+| Cubox i2eX/i4 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 21 | 22 |
+| Inovato Quadra | ✅ | SDIO | XRadio XR819 | 2437 MHz @ 20 | 12 | 23 |
+| NanoPi Duo | ✅ | SDIO | XRadio XR819 | 2437 MHz @ 20 | 1 | 14 |
+| NanoPi K2 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 15 | 22 |
+| NanoPi R1 | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 13 | 15 |
+| NanoPi R4S | ✅ | USB | Ralink RT5370 | 2437 MHz @ 20 | 40 | 25 |
+| Odroid C4 | ✅ | USB | Ralink RT5572 | 5240 MHz @ 40 | 56 | 93 |
+| Orange Pi R1 | ✅ | SDIO | Realtek RTL8189ES | — | 26 | 25 |
+| Orange Pi R1 | ✅ | SDIO | Realtek RTL8189ES | — | 29 | 29 |
+| Orange Pi Zero | ✅ | SDIO | XRadio XR819 | 2437 MHz @ 20 | 5 | 17 |
+| Orange Pi Zero | ✅ | USB | MediaTek MT7601 | 2437 MHz @ 20 | 12 | 13 |
+| Orange Pi Zero Plus | ✅ | SDIO | Realtek RTL8189FS | — | 33 | 27 |
+| Orange Pi Zero Plus | ✅ | SDIO | Realtek RTL8189FS | — | 35 | 26 |
+| Raspberry Pi | ✅ | SDIO | Broadcom (brcmfmac) | 2437 MHz @ 20 | 17 | 24 |
+| Rock 5B Plus | ✅ | USB | Realtek RTL8723BU 802.11b/g/n | 2437 MHz @ 20 | 13 | 17 |
+| Rock 5T | ✅ | USB | Ralink RT5572 | 5240 MHz @ 40 | 53 | 73 |
+| Tanix TX6 | ✅ | USB | Ralink RT2870/RT3070 | 2437 MHz @ 20 | 28 | 10 |
+| Udoo | ✅ | USB | Ralink RT5370 | 2437 MHz @ 20 | 34 | 18 |
 
 <!-- DUT-STOP -->
 


### PR DESCRIPTION
Wireless throughput from the autotests fleet iperf run:
https://github.com/armbian/autotests/actions/runs/28514130105

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/932"><kbd><br> Open WWW preview <br></kbd></a>