### PR TITLE
docs: exclude docs/README.md from mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,12 @@ repo_url: https://github.com/armbian/documentation
 edit_uri: edit/main/docs/
 repo_name: armbian/documentation
 
+# docs/README.md is a folder placeholder for GitHub's directory view; it
+# collides with index.md as the site home. Exclude it from the build so
+# `mkdocs build --strict` does not abort on the conflict warning.
+exclude_docs: |
+  /README.md
+
 theme:
     name: material
     custom_dir: overrides


### PR DESCRIPTION
## Summary

`docs/README.md` is a one-line placeholder that GitHub renders when browsing the `docs/` folder. mkdocs treats it as a second index page for `docs/` and drops it with:

```
WARNING - Excluding 'README.md' from the site because it conflicts with 'index.md'.
```

Under `mkdocs build --strict` that warning becomes an error and aborts the build. This is the only warning on a clean `main`, so `--strict` currently fails repo-wide regardless of content changes.

## Change

Add `exclude_docs: README.md` to `mkdocs.yml`. This drops `README.md` from the site build (no collision, no warning) while keeping the file in the repository for GitHub's folder view.

## Test plan

- [x] `mkdocs build --strict` — before: aborts on the README/index conflict; after: `Documentation built`, exit 0, no warnings.
- [x] `docs/README.md` still present in the tree; `docs/index.md` remains the site home.