### PR TITLE
ci(docs-preview): skip publish/comment steps on fork PRs

### DIFF
--- a/.github/workflows/pdf-at-pr.yaml
+++ b/.github/workflows/pdf-at-pr.yaml
@@ -50,7 +50,12 @@ jobs:
         working-directory: documentation
         run: mkdocs build --clean
 
+      # Publishing the preview and commenting need a writable GITHUB_TOKEN,
+      # which pull_request from a fork does not get (token is read-only there).
+      # Skip these steps for fork PRs so the check stays green after the build
+      # step has already validated the docs; internal branches still publish.
       - name: Publish to `www` branch
+        if: github.event.pull_request.head.repo.full_name == github.repository
         working-directory: www
         run: |
           mkdir -p "${{ github.event.number }}"
@@ -62,6 +67,7 @@ jobs:
           git push origin www || true
 
       - name: Comment on PR with preview link
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: devindford/Append_PR_Comment@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `docs-preview` check is red on every PR opened from a fork, including PRs where the docs build fine. The job runs on the `pull_request` event, where a fork's `GITHUB_TOKEN` is read-only regardless of the workflow's declared `permissions`. The final step, **Comment on PR with preview link** (`devindford/Append_PR_Comment`), then fails:

```
##[error]HttpError: Resource not accessible by integration
```

The `Publish to www branch` step has the same problem but hides it behind `|| true`; the comment step fails hard and turns the check red. The actual `mkdocs build --clean` step succeeds — only the write-back steps can't run.

## Change

Guard the two steps that need a writable token with:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

- **Fork PRs**: the MkDocs build still runs (validating the docs), the publish/comment steps are skipped, and the check goes green.
- **Internal branches** (same-repo PRs): unchanged — preview is published and the comment posted as before.

`pull_request_target` would grant forks a writable token but checks out untrusted PR head with elevated permissions, so it is deliberately avoided.

Note: because `pull_request` runs the workflow from the base branch, this PR's own `docs-preview` run still uses the current (unpatched) workflow and stays red — the guard takes effect only after merge.