### PR TITLE
docs: use unpinned python3-dev in setup instructions

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -50,7 +50,7 @@ Ensure you have Python and the necessary development packages installed:
 
 ```bash
 sudo apt-get update
-sudo apt-get install python3 python3-pip python3-venv python3.12-dev
+sudo apt-get install python3 python3-pip python3-venv python3-dev
 ```
 
 If using Debian, you may need to install the following packages for `mkdocs-material`:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ However, to **enjoy a fully rendered local preview** with proper styling and liv
 
 ```bash
 sudo apt-get update
-sudo apt-get install python3 python3-pip python3-venv python3.12-dev
+sudo apt-get install python3 python3-pip python3-venv python3-dev
 ```
 
 If using Debian, you may need to install the following packages for `mkdocs-material`:


### PR DESCRIPTION
`sudo apt-get install … python3.12-dev` fails on releases whose default Python isn't 3.12 — e.g. **Ubuntu Resolute** (no `python3.12-dev` package).

Swap the version-pinned `python3.12-dev` for the unpinned **`python3-dev`**, which depends on the correct dev headers for the release's default Python (3.13 on Resolute/Trixie, 3.12 on Noble, 3.10 on Jammy, …). Fixed in both `README.md` and `DOCUMENTATION.md` (identical instruction).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/935"><kbd><br> Open WWW preview <br></kbd></a>