### PR TITLE
Build-Switches: document DOCKER_FORCE_PULL

### DIFF
--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -137,6 +137,20 @@ Enables automatic background updates of Docker build images via a system cronjob
     - `/etc/cron.d/armbian-docker-pull` - cronjob (runs at 00:00 and 12:00)
     - `/var/lib/armbian/docker-pull.hash` - configuration hash for update detection
 
+**DOCKER_FORCE_PULL** ( `string` )
+
+- `yes`: force a re-pull of the Docker base image, bypassing the local pull cache
+- `no` (default): reuse the local image if it is present and was pulled within the last ~24 hours
+
+By default the build only pulls the base image when the local copy is missing or its pull marker is older than ~24 hours; otherwise it reuses the local image. Set `DOCKER_FORCE_PULL=yes` to pull the latest published image immediately — useful right after a new framework image is published, so builds pick it up without waiting for the cache to expire or removing the local image by hand.
+
+!!! example "Build switch example"
+
+```sh
+# Force a fresh pull of the base image for this build
+./compile.sh DOCKER_FORCE_PULL=yes BOARD=... BRANCH=...
+```
+
 **DOCKER_PRUNE** ( `string` )
 
 - `yes`: prune old Armbian build images from the local Docker daemon at the start of each build

--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -148,7 +148,7 @@ By default the build only pulls the base image when the local copy is missing or
 
 ```sh
 # Force a fresh pull of the base image for this build
-./compile.sh DOCKER_FORCE_PULL=yes BOARD=... BRANCH=...
+./compile.sh DOCKER_FORCE_PULL=yes BOARD=uefi-x86 BRANCH=current
 ```
 
 **DOCKER_PRUNE** ( `string` )


### PR DESCRIPTION
Documents the `DOCKER_FORCE_PULL=yes` build switch in the Developer Guide → Build Switches, next to `ARMBIAN_DOCKER_AUTO_PULL` and `DOCKER_PRUNE`.

By default the build only pulls the Docker base image when the local copy is missing or its pull marker is older than ~24h; otherwise it reuses the local image. `DOCKER_FORCE_PULL=yes` forces a re-pull so a freshly-published framework image is picked up immediately.

Pairs with the framework switch in armbian/build#10251.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/943"><kbd><br> Open WWW preview <br></kbd></a>