### PR TITLE
Extensions-List: document the image-output-iso extension

### DIFF
--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -194,6 +194,16 @@ Converts the Armbian image into a QDL-flashable archive for Arduino UNO Q (Qualc
 
 ---
 
+## image-output-iso
+
+Builds a bootable **live `.iso`** from a UEFI image so it can be booted from a BMC/IPMI **virtual CD-ROM** (cloud, IPMI, KVM). The ISO carries the kernel, initrd and a squashfs of the rootfs inside ISO9660, with `live-boot` and a self-contained GRUB. Boot the live system, then install to disk with `armbian-install`. Works on `amd64` and `arm64` UEFI targets (uefi-x86 / uefi-arm64); `riscv64` is experimental/untested. Requires the `grub` extension. By default the `.img` is dropped (the ISO carries the rootfs).
+
+The ISO is **UEFI-only** (no legacy BIOS boot) and **Secure Boot must be disabled** (GRUB and the kernel are unsigned).
+
+Parameters: `SKIP_ISO` (skip), `ISO_VOLID` (volume id, max 32 chars, default `ARMBIAN`), `ISO_COMP` (squashfs compressor: `zstd`/`xz`/`gzip`, default `zstd`), `ISO_TIMEOUT` (GRUB menu seconds, default `1`, `0` = boot immediately), `ISO_KEEP_IMG` (`yes` keeps the `.img` alongside the `.iso`).
+
+---
+
 ## image-output-oowow
 
 Creates an image compatible with the OOWOW recovery system for Khadas boards.
@@ -411,16 +421,6 @@ Enables Btrfs filesystem support in U-Boot (`CONFIG_CMD_BTRFS`).
 ## uefi-edk2-rk3588
 
 Integrates UEFI EDK2 firmware for Rockchip RK3588 boards.
-
----
-
-## uefi-iso
-
-Builds a bootable **live `.iso`** from a UEFI image so it can be booted from a BMC/IPMI **virtual CD-ROM** (cloud, IPMI, KVM). The ISO carries the kernel, initrd and a squashfs of the rootfs inside ISO9660, with `live-boot` and a self-contained GRUB. Boot the live system, then install to disk with `armbian-install`. Works on `amd64` and `arm64` UEFI targets (uefi-x86 / uefi-arm64); `riscv64` is experimental/untested. Requires the `grub` extension. By default the `.img` is dropped (the ISO carries the rootfs).
-
-The ISO is **UEFI-only** (no legacy BIOS boot) and **Secure Boot must be disabled** (GRUB and the kernel are unsigned).
-
-Parameters: `SKIP_UEFI_ISO` (skip), `UEFI_ISO_VOLID` (volume id, max 32 chars, default `ARMBIAN`), `UEFI_ISO_COMP` (squashfs compressor: `zstd`/`xz`/`gzip`, default `zstd`), `UEFI_ISO_TIMEOUT` (GRUB menu seconds, default `1`, `0` = boot immediately), `UEFI_ISO_KEEP_IMG` (`yes` keeps the `.img` alongside the `.iso`).
 
 ---
 

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -414,6 +414,16 @@ Integrates UEFI EDK2 firmware for Rockchip RK3588 boards.
 
 ---
 
+## uefi-iso
+
+Builds a bootable **live `.iso`** from a UEFI image so it can be booted from a BMC/IPMI **virtual CD-ROM** (cloud, IPMI, KVM) — the shape a virtual CD actually boots (kernel + initrd + a squashfs of the rootfs inside the ISO9660, with `live-boot` and a self-contained GRUB). Boot the live system, then install to disk with `armbian-install`. Works on `amd64` and `arm64` UEFI targets (uefi-x86 / uefi-arm64); `riscv64` is experimental/untested. Requires the `grub` extension. By default the `.img` is dropped (the ISO carries the rootfs).
+
+The ISO is **UEFI-only** (no legacy BIOS boot) and **Secure Boot must be disabled** (GRUB and the kernel are unsigned).
+
+Parameters: `SKIP_UEFI_ISO` (skip), `UEFI_ISO_VOLID` (volume id, default `ARMBIAN`), `UEFI_ISO_COMP` (squashfs compressor: `zstd`/`xz`/`gzip`), `UEFI_ISO_TIMEOUT` (GRUB menu seconds, `0` = boot immediately), `UEFI_ISO_KEEP_IMG` (`yes` keeps the `.img` alongside the `.iso`).
+
+---
+
 ## ufs
 
 Creates a UFS-sector-aligned image. Requires Debian Trixie (13) or newer as the build host. Set `DOCKER_ARMBIAN_BASE_IMAGE=debian:trixie` when building in Docker.

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -416,11 +416,11 @@ Integrates UEFI EDK2 firmware for Rockchip RK3588 boards.
 
 ## uefi-iso
 
-Builds a bootable **live `.iso`** from a UEFI image so it can be booted from a BMC/IPMI **virtual CD-ROM** (cloud, IPMI, KVM) — the shape a virtual CD actually boots (kernel + initrd + a squashfs of the rootfs inside the ISO9660, with `live-boot` and a self-contained GRUB). Boot the live system, then install to disk with `armbian-install`. Works on `amd64` and `arm64` UEFI targets (uefi-x86 / uefi-arm64); `riscv64` is experimental/untested. Requires the `grub` extension. By default the `.img` is dropped (the ISO carries the rootfs).
+Builds a bootable **live `.iso`** from a UEFI image so it can be booted from a BMC/IPMI **virtual CD-ROM** (cloud, IPMI, KVM). The ISO carries the kernel, initrd and a squashfs of the rootfs inside ISO9660, with `live-boot` and a self-contained GRUB. Boot the live system, then install to disk with `armbian-install`. Works on `amd64` and `arm64` UEFI targets (uefi-x86 / uefi-arm64); `riscv64` is experimental/untested. Requires the `grub` extension. By default the `.img` is dropped (the ISO carries the rootfs).
 
 The ISO is **UEFI-only** (no legacy BIOS boot) and **Secure Boot must be disabled** (GRUB and the kernel are unsigned).
 
-Parameters: `SKIP_UEFI_ISO` (skip), `UEFI_ISO_VOLID` (volume id, default `ARMBIAN`), `UEFI_ISO_COMP` (squashfs compressor: `zstd`/`xz`/`gzip`), `UEFI_ISO_TIMEOUT` (GRUB menu seconds, `0` = boot immediately), `UEFI_ISO_KEEP_IMG` (`yes` keeps the `.img` alongside the `.iso`).
+Parameters: `SKIP_UEFI_ISO` (skip), `UEFI_ISO_VOLID` (volume id, max 32 chars, default `ARMBIAN`), `UEFI_ISO_COMP` (squashfs compressor: `zstd`/`xz`/`gzip`, default `zstd`), `UEFI_ISO_TIMEOUT` (GRUB menu seconds, default `1`, `0` = boot immediately), `UEFI_ISO_KEEP_IMG` (`yes` keeps the `.img` alongside the `.iso`).
 
 ---
 


### PR DESCRIPTION
Adds a reference entry for the **image-output-iso** extension (was `uefi-iso`) to `Developer-Guide_Extensions-List.md`, placed in the `image-output-*` family alongside qcow2/vhdx/ovf/etc.

image-output-iso builds a bootable live `.iso` from a UEFI image for BMC/IPMI **virtual CD-ROM** boot — boot the live system, then install to disk with `armbian-install`. Covers supported arches (amd64/arm64; riscv64 experimental), the `grub` dependency, the UEFI-only / Secure-Boot-off requirements, and the parameters.

Companion to armbian/build#10314.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/949"><kbd><br> Open WWW preview <br></kbd></a>