### PR TITLE
docs: official build host is Debian Trixie

### DIFF
--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -4,8 +4,8 @@
 
 - x86_64 / aarch64 / riscv64 machine
 - at least 8GB (less for non-[BTF](https://docs.kernel.org/bpf/btf.html) builds) of memory and ~50GB of disk space for VM, container, or bare-metal installation
-- **Armbian / Ubuntu Noble 24.04.x** for native building or any Docker capable Linux for containerised
-- **Windows 10/11 with WSL2 subsystem** running Armbian / Ubuntu Noble 24.04.x
+- **Armbian / Debian Trixie 13.x** for native building or any Docker capable Linux for containerised
+- **Windows 10/11 with WSL2 subsystem** running Armbian / Debian Trixie 13.x
 - Superuser rights (configured sudo or root access).
 - Make sure your system is up-to-date! Outdated Docker binaries, for example, can cause trouble
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -4,8 +4,8 @@
 
 - x86_64 / aarch64 / riscv64 machine
 - at least 8GB (less for non-[BTF](https://docs.kernel.org/bpf/btf.html) builds) of memory and ~50GB of disk space for VM, container, or bare-metal installation
-- **Armbian / Debian Trixie 13.x** for native building or any Docker capable Linux for containerised
-- **Windows 10/11 with WSL2 subsystem** running Armbian / Debian Trixie 13.x
+- **Armbian/Debian 13 (Trixie)** for native building or any Docker capable Linux for containerised
+- **Windows 10/11 with WSL2 subsystem** running Armbian/Debian 13 (Trixie)
 - Superuser rights (configured sudo or root access).
 - Make sure your system is up-to-date! Outdated Docker binaries, for example, can cause trouble
 

--- a/docs/Developer-Guide_Building-with-Multipass.md
+++ b/docs/Developer-Guide_Building-with-Multipass.md
@@ -1,6 +1,6 @@
 # Building with Multipass
 
-In order to build an Armbian image from scratch, whether for development purposes or to [apply user customizations](https://docs.armbian.com/Developer-Guide_User-Configurations/) on top of a base image, a build environment is required. Per the Armbian documentation, Debian Trixie is [the officially supported](https://docs.armbian.com/Developer-Guide_Build-Preparation/) build platform. Multipass images are Ubuntu, so this route is a convenience rather than the supported one - for the officially supported host, build natively on Debian Trixie or use [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/).
+In order to build an Armbian image from scratch, whether for development purposes or to [apply user customizations](https://docs.armbian.com/Developer-Guide_User-Configurations/) on top of a base image, a build environment is required. Per the Armbian documentation, Armbian/Debian 13 (Trixie) is [the officially supported](https://docs.armbian.com/Developer-Guide_Build-Preparation/) build platform. Multipass images are Ubuntu, so this route is a convenience rather than the supported one - for the officially supported host, build natively on Armbian/Debian 13 (Trixie) or use [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/).
 
 [Multipass](https://multipass.run/) that is designed for quick and painless provisioning of Ubuntu VMs.
 

--- a/docs/Developer-Guide_Building-with-Multipass.md
+++ b/docs/Developer-Guide_Building-with-Multipass.md
@@ -1,6 +1,6 @@
 # Building with Multipass
 
-In order to build an Armbian image from scratch, whether for development purposes or to [apply user customizations](https://docs.armbian.com/Developer-Guide_User-Configurations/) on top of a base image, a build environment is required. Per the Armbian documentation, Ubuntu 24.04 is [the officially supported](https://docs.armbian.com/Developer-Guide_Build-Preparation/) build platform.
+In order to build an Armbian image from scratch, whether for development purposes or to [apply user customizations](https://docs.armbian.com/Developer-Guide_User-Configurations/) on top of a base image, a build environment is required. Per the Armbian documentation, Debian Trixie is [the officially supported](https://docs.armbian.com/Developer-Guide_Build-Preparation/) build platform. Multipass images are Ubuntu, so this route is a convenience rather than the supported one - for the officially supported host, build natively on Debian Trixie or use [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/).
 
 [Multipass](https://multipass.run/) that is designed for quick and painless provisioning of Ubuntu VMs.
 


### PR DESCRIPTION
Counterpart to armbian/build#10494. Two places in the docs still named Ubuntu 24.04 as the official host.

## `Developer-Guide_Build-Preparation.md` — the authoritative statement

```diff
-- **Armbian / Ubuntu Noble 24.04.x** for native building or any Docker capable Linux for containerised
-- **Windows 10/11 with WSL2 subsystem** running Armbian / Ubuntu Noble 24.04.x
+- **Armbian / Debian Trixie 13.x** for native building or any Docker capable Linux for containerised
+- **Windows 10/11 with WSL2 subsystem** running Armbian / Debian Trixie 13.x
```

## `Developer-Guide_Building-with-Multipass.md` — repeated the claim

It said *"Ubuntu 24.04 is the officially supported build platform"* and linked to the page above, so it contradicted the switch. Multipass only ships Ubuntu images, so the guide keeps its Ubuntu instance and now says plainly that it is a convenience route, pointing at native Trixie or Docker for the supported one.

## Checked and deliberately left alone

- `Developer-Guide_Build-Switches.md` `noble`/`jammy` entries — those are `RELEASE=` values for the **image being built**, not the host.
- `Developer-Guide_Building-with-Docker.md` — already host-agnostic.
- `User-Guide_FAQ.md`, `Release_Changelog.md` — userspace upgrade paths and historic release notes.
- The Multipass guide still provisions a **Jammy 22.04** instance further down (`multipass launch … --name jammy`), which was already stale before this change. Refreshing that guide is a separate job.

## Not a docs issue, but worth knowing

`lib/functions/host/docker.sh:146` still defaults `DOCKER_ARMBIAN_BASE_IMAGE` to `ubuntu:noble`, with `debian:trixie` commented out directly above, while the auto-pull list already fetches `armbian-debian-trixie-latest`. Flagged on armbian/build#10494.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/974"><kbd><br> Open WWW preview <br></kbd></a>