### PR TITLE
css: uniform app-page logo size (.app-logo)

### DIFF
--- a/docs/css/armbian-extra.css
+++ b/docs/css/armbian-extra.css
@@ -50,3 +50,13 @@ pre.custom-bash-block, code.custom-bash-block {
     font-size: 12pt; /* even smaller for small phones */
   }
 }
+
+/* App-page logos: source images vary wildly (square icons to wide banners), so
+ * render them all within one consistent box for a uniform visual size. */
+.md-typeset img.app-logo {
+  height: auto;
+  width: auto;
+  max-height: 88px;
+  max-width: 260px;
+  object-fit: contain;
+}


### PR DESCRIPTION
App-page logos come from source images of wildly varying dimensions (square icons to wide banners to 1920×1080), so they render at different sizes.

Adds a `.app-logo` rule that boxes every logo to one consistent visual size (`max-height: 88px; max-width: 260px; object-fit: contain`, aspect preserved). The class is emitted by the generator in the paired **armbian/configng** PR.

Merge together; the regenerated app pages carrying the class arrive via the automated "Pull from Armbian config" PR after the configng change lands. Harmless before then (the rule just matches nothing).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/981"><kbd><br> Open WWW preview <br></kbd></a>