### PR TITLE
nav: point Unit Test Status at the unit tests

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,7 +142,7 @@ nav:
         - 'FAQ' : 'User-Guide_FAQ.md'
         - 'Appendix' :
             - 'Release Model' : 'Process_Release-Model.md'
-            - 'Unit Test Status' : '/'
+            - 'Unit Test Status' : 'https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml'
   - 'RELEASES':
         - 'Release notes': 'releases/index.md'
   - 'ARMBIAN CONFIG':


### PR DESCRIPTION
`Appendix → Unit Test Status` in the nav linked to `'/'` — the site root — so clicking it sent readers back to the front page.

```yaml
-            - 'Unit Test Status' : '/'
+            - 'Unit Test Status' : 'https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml'
```

The status it means is the configng `maintenance-unit-tests` workflow, which is already what the "Unit testing" badge on the front page (`docs/index.md`) points to — so this makes the nav agree with the page it sits next to.

Predates the release-notes work (came in with `1ae40934`, "Move changelog and release model to appendix"); spotted while reviewing that.

### Verification

`mkdocs build --strict` clean, and in the built HTML:

```html
<a href="https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml" class="md-nav__link">
  <span class="md-ellipsis">Unit Test Status</span>
```

Nav entries still pointing at the site root: **0**.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/987"><kbd><br> Open WWW preview <br></kbd></a>