### PR TITLE
index: give the homepage its own title, description and social image

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+title: Armbian — Linux for ARM single-board computers
+description: "Armbian is a lean Debian and Ubuntu based Linux for ARM and RISC-V single-board computers. Docs for installing, configuring and building your own images."
+image: /images/armbian-logo.png
+---
+
 # Armbian OS
 
 ![Armbian logo](images/logo-small.png){ width=25% }
@@ -11,7 +17,7 @@ Welcome to the official documentation of Armbian Linux, a highly optimized base 
 
 The table of contents in the sidebar and the links at the top of the page should let you easily access the documentation for your topic of interest.
 
-If you are **new to Armbian**, the [_Introduction_](index.md) and the [_Getting Started_](User-Guide_Getting-Started.md) sections provide everything you need to know about the project, where to find the resources for your board, and a tutorial for everything you need to get Armbian running and configured.
+If you are **new to Armbian**, this _Introduction_ and the [_Getting Started_](User-Guide_Getting-Started.md) sections provide everything you need to know about the project, where to find the resources for your board, and a tutorial for everything you need to get Armbian running and configured.
 
 It then continues on to [_Advanced Configuration_](User-Guide_Advanced-Configuration.md) tasks and tools for **advanced users**. The topics in this section cover a wide range of tasks: configuring the system or the network without using [`armbian-config`](config/index.md), configuring your device automatically at first boot, and creating a custom image using the [`Armbian Build Framework`](Developer-Guide_Overview.md).
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,7 +6,11 @@
      `image:` in front-matter). Falls back to the site defaults elsewhere. -->
 {% block extrahead %}
   {{ super() }}
-  {% set _title = (page.title ~ " - " ~ config.site_name) if page and page.title else config.site_name %}
+  {# page.title is the nav label, which the theme's <title> overrides with
+     page.meta.title when a page sets one. Follow the same order here so the
+     social cards do not disagree with the browser title. #}
+  {% set _page_title = (page.meta.title if page and page.meta and page.meta.title else (page.title if page else None)) %}
+  {% set _title = (_page_title ~ " - " ~ config.site_name) if _page_title else config.site_name %}
   {% set _desc = (page.meta.description if page and page.meta and page.meta.description else config.site_description) %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ _title }}">


### PR DESCRIPTION
`docs/index.md` is the highest-authority page on the domain and was still served with the sitewide boilerplate.

**Before**

| | |
|---|---|
| `<title>` | `Introduction - Armbian Documentation` |
| `<meta name="description">` | `Official documentation for Armbian OS and Armbian build framework` (shared with 50 other pages) |
| `og:image` | absent |
| `twitter:card` | `summary` (software pages use `summary_large_image`) |

**After**

| | |
|---|---|
| `<title>` | `Armbian — Linux for ARM single-board computers - Armbian Documentation` |
| `<meta name="description">` | `Armbian is a lean Debian and Ubuntu based Linux for ARM and RISC-V single-board computers. Docs for installing, configuring and building your own images.` (153 chars) |
| `og:image` | `https://docs.armbian.com/images/armbian-logo.png` |
| `twitter:card` | `summary_large_image` |

## Changes

- **`docs/index.md`** — added `title`, `description` and `image` front matter. `image:` reuses the existing `docs/images/armbian-logo.png` (512×512); no new asset was generated. The override already turns `image:` into `og:image` + `twitter:image` + `summary_large_image`, so aligning the card needed no template change.
- **`overrides/main.html`** — the social title was built from `page.title`, which mkdocs fills from the **nav label** ("Introduction"), not from front matter. The theme's `<title>` prefers `page.meta.title`. So `<title>` and `og:title` would have disagreed on this page. The override now follows the theme's order. No other page changes: every page whose nav label and front-matter title already match renders identically (verified against `software/docker/`).
- **`docs/index.md`** — the "If you are **new to Armbian**" paragraph linked *Introduction* to `index.md`, i.e. to itself. Self-link removed; the wording is now "this _Introduction_".

## Notes

- The theme appends ` - {site_name}` to any front-matter title, so the rendered `<title>` is 70 characters. The distinctive words lead, so a SERP truncation still shows "Armbian — Linux for ARM single-board computers". Removing the suffix would need a `htmltitle` block override affecting every page, which felt out of scope here.
- 50 pages still carry the sitewide boilerplate description. Out of scope for this PR, which only covers the homepage.

## Verification

- `mkdocs build --strict` passes, no new warnings.
- The homepage `<title>` and `<meta name="description">` are each unique across the built site (`grep -rl … | wc -l` → 1).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/993"><kbd><br> Open WWW preview <br></kbd></a>