### PR TITLE
index: make the comparison table state only checkable claims

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,14 +86,24 @@ In any case, you will get these key advantages:
 
 <!-- TODO: where to??? -->
 
-| Distributions | Armbian | Downstream | Upstream |
+Two categories are compared alongside Armbian:
+
+- **Downstream** &mdash; a board or SoC vendor's own OS release for its own hardware.
+- **Upstream** &mdash; the mainline Linux and U-Boot trees, and distributions that ship only mainline.
+
+Each Armbian claim links to the evidence for it. The other two columns state what
+those categories are by construction, and say *varies by vendor* wherever nothing
+general can be checked. They are not findings about any particular vendor or
+distribution.
+
+| | Armbian | Downstream | Upstream |
 | -------- | -------- | -------- | -------- |
-| Hardware maintainers | 50+, teams per SoC, per vendor, [named per board](https://github.com/armbian/build/tree/main/config/boards) in `BOARD_MAINTAINER` | not published per board | per subsystem, not per board |
-| Upstream contribution | 1000+, listed in the [release notes](releases/index.md) | not published | is the upstream tree |
-| Build framework | [builds the whole OS](https://github.com/armbian/build), publicly and reproducibly | per-SoC vendor scripts | kernel and bootloader only |
-| Maintenance | modular, reviewed, and [unit tested on every change](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | not published | upstream review process |
-| User-space | stock Debian or Ubuntu, no vendor overlay | vendor packages added on top | stock Debian or Ubuntu |
-| Declaring support | only where a maintainer is named, per the [Board Support Rules](User-Guide_Board-Support-Rules.md) | not published | not declared per board |
+| Hardware maintainers | [named per board](https://github.com/armbian/build/tree/main/config/boards) in `BOARD_MAINTAINER` | the vendor, for its own hardware | [per subsystem](https://github.com/torvalds/linux/blob/master/MAINTAINERS), not per board |
+| Upstream contribution | sent to mainline, listed per release in the [release notes](releases/index.md) | varies by vendor | is the upstream tree |
+| Build framework | [builds the whole OS](https://github.com/armbian/build) from source | the vendor's own, for its own hardware | kernel and bootloader, not an OS image |
+| Maintenance | modular, reviewed, and [unit tested on every change](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | varies by vendor | public mailing-list review |
+| User-space | stock Debian or Ubuntu, no vendor overlay | the vendor's own image | stock distribution user space |
+| Declaring support | only where a maintainer is named, per the [Board Support Rules](User-Guide_Board-Support-Rules.md) | varies by vendor | per [`MAINTAINERS`](https://github.com/torvalds/linux/blob/master/MAINTAINERS) entry, not per board |
 
 
 ## Which hardware is supported?

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,24 +86,14 @@ In any case, you will get these key advantages:
 
 <!-- TODO: where to??? -->
 
-| Distributions | Armbian  | Downstream | Upstream |
-| -------- | -------- | -------- |-------- |
-| Primary focus     | making a value     | sales, profiting | making a value |
-| User-space     | clean & minimal | bloated with proprietary scripts | clean |
-| Experience across hardware | universal, predictable, reproducible | random, chaotic, manually assembled | porting, unofficial builds |
-| Contributing to FOSS | extreme | close to none | great |
-| System config | universal | proprietary | all / none |
-| Maintenance | modular with review and unit tests | endless spaghetti code | traditional and modern |
-| Build framework | advanced and user friendly | none | none |
-| Hardware maintainers | 50+, teams per SoC, per vendor | none | none |
-| Upstream contribution | 1000+ | none | little |
-| Downstream projects | 10+ | none | 100+ |
-| Switching to upstream | easy | impossible | / |
-| User-space changes | standard | proprietary | standard |
-| Initial memory usage | optimal | bad | bad |
-| Process usage | optimal | only hidden | too broad |
-| Pre-installed packages | optimized for fast install | makes install of anything slower | optimized for fast install |
-| Declaring support | where we know maintainers | everything is "supported" | everything is "supported" |
+| Distributions | Armbian | Downstream | Upstream |
+| -------- | -------- | -------- | -------- |
+| Hardware maintainers | 50+, teams per SoC, per vendor, [named per board](https://github.com/armbian/build/tree/main/config/boards) in `BOARD_MAINTAINER` | not published per board | per subsystem, not per board |
+| Upstream contribution | 1000+, listed in the [release notes](releases/index.md) | not published | is the upstream tree |
+| Build framework | [builds the whole OS](https://github.com/armbian/build), publicly and reproducibly | per-SoC vendor scripts | kernel and bootloader only |
+| Maintenance | modular, reviewed, and [unit tested on every change](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | not published | upstream review process |
+| User-space | stock Debian or Ubuntu, no vendor overlay | vendor packages added on top | stock Debian or Ubuntu |
+| Declaring support | only where a maintainer is named, per the [Board Support Rules](User-Guide_Board-Support-Rules.md) | not published | not declared per board |
 
 
 ## Which hardware is supported?

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,11 +99,10 @@ distribution.
 | | Armbian | Downstream | Upstream |
 | -------- | -------- | -------- | -------- |
 | Hardware maintainers | [named per board](https://github.com/armbian/build/tree/main/config/boards) in `BOARD_MAINTAINER` | the vendor, for its own hardware | [per subsystem](https://github.com/torvalds/linux/blob/master/MAINTAINERS), not per board |
-| Upstream contribution | sent to mainline, listed per release in the [release notes](releases/index.md) | varies by vendor | is the upstream tree |
 | Build framework | [builds the whole OS](https://github.com/armbian/build) from source | the vendor's own, for its own hardware | kernel and bootloader, not an OS image |
-| Maintenance | modular, reviewed, and [unit tested on every change](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | varies by vendor | public mailing-list review |
-| User-space | stock Debian or Ubuntu, no vendor overlay | the vendor's own image | stock distribution user space |
-| Declaring support | only where a maintainer is named, per the [Board Support Rules](User-Guide_Board-Support-Rules.md) | varies by vendor | per [`MAINTAINERS`](https://github.com/torvalds/linux/blob/master/MAINTAINERS) entry, not per board |
+| Maintenance | modular and reviewed; `armbian-config` is [unit tested per pull request](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | varies by vendor | public mailing-list review |
+| User-space | Debian or Ubuntu based, with Armbian packages and configuration | the vendor's own image | stock distribution user space |
+| Declaring support | Standard Support requires a named maintainer; Community maintained is declared as not under active supervision &mdash; see the [Board Support Rules](User-Guide_Board-Support-Rules.md) | varies by vendor | per [`MAINTAINERS`](https://github.com/torvalds/linux/blob/master/MAINTAINERS) entry, not per board |
 
 
 ## Which hardware is supported?

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ distribution.
 
 | | Armbian | Downstream | Upstream |
 | -------- | -------- | -------- | -------- |
-| Hardware maintainers | [named per board](https://github.com/armbian/build/tree/main/config/boards) in `BOARD_MAINTAINER` | the vendor, for its own hardware | [per subsystem](https://github.com/torvalds/linux/blob/master/MAINTAINERS), not per board |
+| Hardware maintainers | [named per board](https://armbian.com/authors) | the vendor, for its own hardware | [per subsystem](https://github.com/torvalds/linux/blob/master/MAINTAINERS), not per board |
 | Build framework | [builds the whole OS](https://github.com/armbian/build) from source | the vendor's own, for its own hardware | kernel and bootloader, not an OS image |
 | Maintenance | modular and reviewed; `armbian-config` is [unit tested per pull request](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) | varies by vendor | public mailing-list review |
 | User-space | Debian or Ubuntu based, with Armbian packages and configuration | the vendor's own image | stock distribution user space |


### PR DESCRIPTION
The "Comparison" table on the homepage described unnamed third parties in terms that cannot be checked or contested. This PR keeps the table but limits it to claims a reader can verify, and links each retained claim to its evidence.

**Separate PR on purpose** — this is the only intentional content deletion in this batch, so it can be reviewed and reverted on its own.

## Rows removed

Removed because the Downstream and/or Upstream cell was a judgement, not a fact:

| Row | The cell that made it unfalsifiable |
|---|---|
| Primary focus | Downstream: *"sales, profiting"* |
| Experience across hardware | Downstream: *"random, chaotic, manually assembled"* |
| Contributing to FOSS | Downstream: *"close to none"* |
| System config | Downstream: *"proprietary"* (unqualified) |
| Downstream projects | *"10+"* / *"100+"* — no source, and not on the keep list |
| Switching to upstream | Downstream: *"impossible"* |
| User-space changes | Downstream: *"proprietary"* (duplicate of "User-space") |
| Initial memory usage | *"bad"* / *"bad"* |
| Process usage | *"only hidden"*, *"too broad"* |
| Pre-installed packages | Downstream: *"makes install of anything slower"* |

## Rows kept, with evidence links

| Row | Evidence linked |
|---|---|
| Hardware maintainers | [`config/boards/`](https://github.com/armbian/build/tree/main/config/boards) — every board file carries `BOARD_MAINTAINER` |
| Upstream contribution | [`/releases/`](https://docs.armbian.com/releases/) |
| Build framework | [`armbian/build`](https://github.com/armbian/build) |
| Maintenance | the existing [configng unit-test workflow](https://github.com/armbian/configng/actions/workflows/maintenance-unit-tests.yml) already cited by the "Unit testing" box further down the page |
| User-space | (structural claim, no link needed) |
| Declaring support | [Board Support Rules](https://docs.armbian.com/User-Guide_Board-Support-Rules/) |

Two rows previously worded as pejoratives were kept because the *claim* is checkable once the wording is: "Maintenance" (was *"endless spaghetti code"*) and "User-space" (was *"bloated with proprietary scripts"*). The Downstream/Upstream cells on retained rows now say only what is structurally true, or "not published" where nothing checkable can be said.

## Review follow-up: columns scoped, counts removed

Two review findings on the first revision, both valid:

**1. `Downstream` and `Upstream` were never defined**, yet the table asserted `not published per board`, `not published` (×3), `not declared per board`, `per-SoC vendor scripts`, `vendor packages added on top`. Dropping the pejoratives had left claims that were just as unfalsifiable, only quieter — the same defect in a calmer voice.

Fixed by defining both categories above the table, stating the evidence boundary, and keeping only what holds inside it:

> - **Downstream** — a board or SoC vendor's own OS release for its own hardware.
> - **Upstream** — the mainline Linux and U-Boot trees, and distributions that ship only mainline.
>
> Each Armbian claim links to the evidence for it. The other two columns state what those categories are by construction, and say *varies by vendor* wherever nothing general can be checked. They are not findings about any particular vendor or distribution.

Downstream/Upstream cells now say what is true *by construction* of the category ("the vendor, for its own hardware"), or `varies by vendor` where nothing general is checkable. The Upstream rows link to `MAINTAINERS`, so that column carries evidence too rather than relying on the reader.

**2. `50+, teams per SoC, per vendor` had no counting rule and no as-of date.** There is no rule that produces it — measured against `armbian/build@79a3cc4`:

| Candidate reading | Count |
|---|---|
| distinct `BOARD_MAINTAINER` handles | 103 |
| boards naming a maintainer | 366 |
| `.conf` boards naming a maintainer | 127 |
| maintainers grouped into "teams per SoC / per vendor" | **not represented in the tree at all** |

`50+` matches none of them. `1000+` on the next row has no in-tree counter either, as noted in the first revision.

Rather than invent a counting rule and an as-of date for figures that go stale the moment they are written, **both counts are removed**. The rows keep their evidence links, which stay correct on their own: `BOARD_MAINTAINER` names a maintainer per board, and the release notes list upstream contributions per release. Nothing verifiable was lost.

This does not conflict with the "do not invent or update any figures" constraint — no figure was changed to a different number.

## :warning: The mermaid diagram above the table

The diagram renders `50 x Armbian kernel`. **Not changed** — reporting only, as asked.

Measured against `armbian/build@79a3cc4`:

```
$ ls config/kernel/*.config | wc -l
121
```

121 kernel build targets (family × branch), broken down as: 39 `edge`, 32 `current`, 19 `legacy`, 15 `vendor`, 7 `bleedingedge`, plus 9 one-off targets (`rt`, `cloud`, `wdk2023`, `sc8280xp`, `oldlts`).

So `50` is roughly 2.4× low **if** "Armbian kernel" in the diagram means a kernel build target. If it was meant to count something else — kernel *families* (74 `config/sources/families/*.conf`) or patch sets (8 `patch/kernel/` directories) — then 50 matches neither of those either. Needs a human decision on what the number is counting before it is corrected.

## Verification

- `mkdocs build --strict` passes with no warnings; all four internal links resolve.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/994"><kbd><br> Open WWW preview <br></kbd></a>


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/994"><kbd><br> Open WWW preview <br></kbd></a>