### PR TITLE
redirects: drop the /armbian-config/ map, add the one that was missing

### DIFF
--- a/docs/User-Guide_Armbian-Software/Armbian.md
+++ b/docs/User-Guide_Armbian-Software/Armbian.md
@@ -6,7 +6,7 @@ comments: true
 # Armbian infrastructure services
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [CDN router](/software/cdn-router/) — Router for repository mirror automation
 - [GH runners](/software/gh-runners/) — GitHub runners for Armbian automation

--- a/docs/User-Guide_Armbian-Software/Backup.md
+++ b/docs/User-Guide_Armbian-Software/Backup.md
@@ -6,6 +6,6 @@ comments: true
 # Backup solutions for your data
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Duplicati](/software/duplicati/) — Duplicati install

--- a/docs/User-Guide_Armbian-Software/Containers.md
+++ b/docs/User-Guide_Armbian-Software/Containers.md
@@ -6,7 +6,7 @@ comments: true
 # Docker containerization and KVM virtual machines
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Docker](/software/docker/) — Docker
 - [Portainer](/software/portainer/) — Portainer container management platform

--- a/docs/User-Guide_Armbian-Software/DNS.md
+++ b/docs/User-Guide_Armbian-Software/DNS.md
@@ -6,7 +6,7 @@ comments: true
 # Network-wide ad blockers servers
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [AdGuardHome](/software/adguardhome/) — AdGuardHome DNS sinkhole
 - [Pi-hole](/software/pi-hole/) — Pi-hole DNS ad blocker with Unbound support

--- a/docs/User-Guide_Armbian-Software/Database.md
+++ b/docs/User-Guide_Armbian-Software/Database.md
@@ -6,7 +6,7 @@ comments: true
 # SQL database servers and web interface managers
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [MySQL](/software/mysql/) — MySQL SQL database server
 - [Mariadb](/software/mariadb/) — Mariadb SQL database server

--- a/docs/User-Guide_Armbian-Software/DevTools.md
+++ b/docs/User-Guide_Armbian-Software/DevTools.md
@@ -6,7 +6,7 @@ comments: true
 # Applications and tools for development
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Git CLI](/software/git-cli/) — Install tools for cloning and managing repositories (git)
 - [Code-server](/software/code-server/) — Code-server VS Code in browser

--- a/docs/User-Guide_Armbian-Software/Downloaders.md
+++ b/docs/User-Guide_Armbian-Software/Downloaders.md
@@ -6,7 +6,7 @@ comments: true
 # Download apps for movies, TV shows, music and subtitles
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Bazarr](/software/bazarr/) — Bazarr automatic subtitles downloader for Sonarr and Radarr
 - [Deluge](/software/deluge/) — Deluge BitTorrent client

--- a/docs/User-Guide_Armbian-Software/Finance.md
+++ b/docs/User-Guide_Armbian-Software/Finance.md
@@ -6,7 +6,7 @@ comments: true
 # Manage your finances
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Actual Budget](/software/actual-budget/) — Do your finances with Actual Budget
 - [Wallos](/software/wallos/) — Install Wallos subscription tracker

--- a/docs/User-Guide_Armbian-Software/HomeAutomation.md
+++ b/docs/User-Guide_Armbian-Software/HomeAutomation.md
@@ -6,7 +6,7 @@ comments: true
 # Home Automation for control home appliances
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Domoticz](/software/domoticz/) — Domoticz open source home automation
 - [EVCC](/software/evcc/) — EVCC - solar charging automation

--- a/docs/User-Guide_Armbian-Software/Management.md
+++ b/docs/User-Guide_Armbian-Software/Management.md
@@ -6,7 +6,7 @@ comments: true
 # Remote File & Management tools
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Cockpit](/software/cockpit/) — Cockpit OS and VM management tool
 - [Proxmox VE](/software/proxmox-ve/) — Proxmox VE virtualization platform (keeps the Armbian kernel)

--- a/docs/User-Guide_Armbian-Software/Media.md
+++ b/docs/User-Guide_Armbian-Software/Media.md
@@ -6,7 +6,7 @@ comments: true
 # Media servers, organizers and editors
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Emby](/software/emby/) — Emby organizes video, music, live TV, and photos
 - [Filebrowser](/software/filebrowser/) — Filebrowser provides a web-based file manager accessible via a browser

--- a/docs/User-Guide_Armbian-Software/Monitoring.md
+++ b/docs/User-Guide_Armbian-Software/Monitoring.md
@@ -6,7 +6,7 @@ comments: true
 # Real-time monitoring, collecting metrics, up-time status
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [Grafana](/software/grafana/) — Grafana data analytics
 - [NetAlertX](/software/netalertx/) — NetAlertX network scanner & notification framework

--- a/docs/User-Guide_Armbian-Software/Netconfig.md
+++ b/docs/User-Guide_Armbian-Software/Netconfig.md
@@ -6,7 +6,7 @@ comments: true
 # Console network tools for measuring load and bandwidth
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [avahi-daemon](/software/avahi-daemon/) — avahi-daemon hostname broadcast via mDNS
 - [iperf3](/software/iperf3/) — iperf3 bandwidth measuring tool

--- a/docs/User-Guide_Armbian-Software/Printing.md
+++ b/docs/User-Guide_Armbian-Software/Printing.md
@@ -6,6 +6,6 @@ comments: true
 # Tools for printing and 3D printing
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [OctoPrint](/software/octoprint/) — OctoPrint web-based 3D printers management tool

--- a/docs/User-Guide_Armbian-Software/VPN.md
+++ b/docs/User-Guide_Armbian-Software/VPN.md
@@ -6,7 +6,7 @@ comments: true
 # Virtual Private Network tools
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [WireGuard](/software/wireguard/) — WireGuard VPN server
 - [ZeroTier](/software/zerotier/) — ZeroTier connect devices over your own private network in the world

--- a/docs/User-Guide_Armbian-Software/WebHosting.md
+++ b/docs/User-Guide_Armbian-Software/WebHosting.md
@@ -6,7 +6,7 @@ comments: true
 # Web server, LEMP, reverse proxy, Let's Encrypt SSL
 
 
-Install and configure these applications through [`armbian-config`](/armbian-config/) or from the pages below:
+Install and configure these applications through [`armbian-config`](/config/) or from the pages below:
 
 - [SWAG](/software/swag/) — SWAG reverse proxy
 - [Ghost](/software/ghost/) — Ghost CMS install

--- a/docs/software/actual-budget.md
+++ b/docs/software/actual-budget.md
@@ -30,7 +30,7 @@ comments: true
 <!--- header STOP from tools/include/markdown/ABU001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Finance → Actual Budget**
+Install from **[armbian-config](/config/) → Software → Finance → Actual Budget**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd ABU001

--- a/docs/software/adguardhome.md
+++ b/docs/software/adguardhome.md
@@ -22,7 +22,7 @@ AdGuard Home is a network-wide software that functions as a DNS server and ad bl
 <!--- header STOP from tools/include/markdown/ADG001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → DNS → AdGuardHome**
+Install from **[armbian-config](/config/) → Software → DNS → AdGuardHome**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd ADG001

--- a/docs/software/apt-cacher-ng.md
+++ b/docs/software/apt-cacher-ng.md
@@ -29,7 +29,7 @@ comments: true
 <!--- header STOP from tools/include/markdown/APT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → apt-cacher-ng**
+Install from **[armbian-config](/config/) → Software → Management → apt-cacher-ng**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd APT001

--- a/docs/software/avahi-daemon.md
+++ b/docs/software/avahi-daemon.md
@@ -19,7 +19,7 @@ avahi-daemon hostname broadcast via mDNS
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://netbox.readthedocs.io/en/stable/) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8222`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Netconfig → avahi-daemon**
+Install from **[armbian-config](/config/) → Software → Netconfig → avahi-daemon**
 
 ~~~ custombash title="avahi-daemon hostname broadcast via mDNS"
 armbian-config --cmd AVH001

--- a/docs/software/bazarr.md
+++ b/docs/software/bazarr.md
@@ -22,7 +22,7 @@ Bazarr is a companion application to Sonarr and Radarr. It can manage and downlo
 <!--- header STOP from tools/include/markdown/BAZ001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Bazarr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Bazarr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd BAZ001

--- a/docs/software/cdn-router.md
+++ b/docs/software/cdn-router.md
@@ -22,7 +22,7 @@ The Armbian Router is an intelligent redirector system that optimizes file downl
 <!--- header STOP from tools/include/markdown/ART001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Armbian → CDN router**
+Install from **[armbian-config](/config/) → Software → Armbian → CDN router**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd ART001

--- a/docs/software/cockpit.md
+++ b/docs/software/cockpit.md
@@ -37,7 +37,7 @@ Here’s a subset of tasks you can perform on each host running Cockpit
 <!--- header STOP from tools/include/markdown/CPT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → Cockpit**
+Install from **[armbian-config](/config/) → Software → Management → Cockpit**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd CPT001

--- a/docs/software/code-server.md
+++ b/docs/software/code-server.md
@@ -39,7 +39,7 @@ Perfect for developers working on **ARM-based SBCs**, **cloud instances**, or **
 <!--- header STOP from tools/include/markdown/COD001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Dev Tools → Code-server**
+Install from **[armbian-config](/config/) → Software → Dev Tools → Code-server**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd COD001

--- a/docs/software/deluge.md
+++ b/docs/software/deluge.md
@@ -22,7 +22,7 @@ Deluge⁠ is a lightweight, Free Software, cross-platform BitTorrent client.
 <!--- header STOP from tools/include/markdown/DEL001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Deluge**
+Install from **[armbian-config](/config/) → Software → Downloaders → Deluge**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd DEL001

--- a/docs/software/docker.md
+++ b/docs/software/docker.md
@@ -19,7 +19,7 @@ Docker helps developers build, share, run, and verify applications anywhere - wi
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> <span style="background-color:#fff3bf; color:#7c4d00; padding:3px 6px; border-radius:4px; font-size:90%;">armhf</span> <span style="background-color:#f3d9fa; color:#6a1b9a; padding:3px 6px; border-radius:4px; font-size:90%;">riscv64</span> · <span style="background-color:#ffffff; color:#039BE5; padding:3px 6px; border-radius:4px; font-size:90%;">🐳 Docker</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://docs.docker.com)
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Containers → Docker**
+Install from **[armbian-config](/config/) → Software → Containers → Docker**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd CON001

--- a/docs/software/domoticz.md
+++ b/docs/software/domoticz.md
@@ -35,7 +35,7 @@ Domoticz is an open-source home automation platform that allows you to control a
 <!--- header STOP from tools/include/markdown/DOM001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Home Automation → Domoticz**
+Install from **[armbian-config](/config/) → Software → Home Automation → Domoticz**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd DOM001

--- a/docs/software/dozzle.md
+++ b/docs/software/dozzle.md
@@ -42,7 +42,7 @@ For more information and usage examples, visit the official [Dozzle documentatio
 <!--- header STOP from tools/include/markdown/DOZ001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → Dozzle**
+Install from **[armbian-config](/config/) → Software → Monitoring → Dozzle**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd DOZ001

--- a/docs/software/duplicati.md
+++ b/docs/software/duplicati.md
@@ -31,7 +31,7 @@ Thanks to Duplicati’s smart design — working through standard protocols and 
 <!--- header STOP from tools/include/markdown/DPL001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Backup → Duplicati**
+Install from **[armbian-config](/config/) → Software → Backup → Duplicati**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd DPL001

--- a/docs/software/emby.md
+++ b/docs/software/emby.md
@@ -22,7 +22,7 @@ Emby organizes video, music, live TV, and photos from personal media libraries a
 <!--- header STOP from tools/include/markdown/EMB001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Emby**
+Install from **[armbian-config](/config/) → Software → Media → Emby**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd EMB001

--- a/docs/software/evcc.md
+++ b/docs/software/evcc.md
@@ -22,7 +22,7 @@ evcc is an energy management system with a focus on electromobility. The softwar
 <!--- header STOP from tools/include/markdown/EVCC01-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Home Automation → EVCC**
+Install from **[armbian-config](/config/) → Software → Home Automation → EVCC**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd EVCC01

--- a/docs/software/filebrowser.md
+++ b/docs/software/filebrowser.md
@@ -33,7 +33,7 @@ Official site: [https://filebrowser.org](https://filebrowser.org)
 <!--- header STOP from tools/include/markdown/FIL001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Filebrowser**
+Install from **[armbian-config](/config/) → Software → Media → Filebrowser**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd FIL001

--- a/docs/software/gh-runners.md
+++ b/docs/software/gh-runners.md
@@ -22,7 +22,7 @@ This module automates the installation, removal, and status checking of GitHub s
 <!--- header STOP from tools/include/markdown/GHR001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Armbian → GH runners**
+Install from **[armbian-config](/config/) → Software → Armbian → GH runners**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd GHR001

--- a/docs/software/ghost.md
+++ b/docs/software/ghost.md
@@ -22,7 +22,7 @@ Ghost is a powerful open-source publishing platform designed for professional pu
 <!--- header STOP from tools/include/markdown/GHOST1-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Web Hosting → Ghost**
+Install from **[armbian-config](/config/) → Software → Web Hosting → Ghost**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd GHOST1

--- a/docs/software/git-cdn.md
+++ b/docs/software/git-cdn.md
@@ -19,7 +19,7 @@ git_cdn GitHub caching proxy install
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · <span style="background-color:#ffffff; color:#039BE5; padding:3px 6px; border-radius:4px; font-size:90%;">🐳 Docker</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://gitlab.com/grouperenault/git_cdn) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8000`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → git_cdn**
+Install from **[armbian-config](/config/) → Software → Management → git_cdn**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd GCD001

--- a/docs/software/git-cli.md
+++ b/docs/software/git-cli.md
@@ -19,7 +19,7 @@ Install tools for cloning and managing repositories (git)
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> <span style="background-color:#fff3bf; color:#7c4d00; padding:3px 6px; border-radius:4px; font-size:90%;">armhf</span> <span style="background-color:#f3d9fa; color:#6a1b9a; padding:3px 6px; border-radius:4px; font-size:90%;">riscv64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://git-scm.com/doc)
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Dev Tools → Git CLI**
+Install from **[armbian-config](/config/) → Software → Dev Tools → Git CLI**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd GIT001

--- a/docs/software/grafana.md
+++ b/docs/software/grafana.md
@@ -21,7 +21,7 @@ Grafana is a multi-platform open source analytics and interactive visualization 
 <!--- header STOP from tools/include/markdown/GRA001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → Grafana**
+Install from **[armbian-config](/config/) → Software → Monitoring → Grafana**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd GRA001

--- a/docs/software/hastebin.md
+++ b/docs/software/hastebin.md
@@ -22,7 +22,7 @@ Hastebin is a fast and simple self-hosted pastebin server. It allows users to qu
 <!--- header STOP from tools/include/markdown/HPS001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Hastebin**
+Install from **[armbian-config](/config/) → Software → Media → Hastebin**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd HPS001

--- a/docs/software/home-assistant.md
+++ b/docs/software/home-assistant.md
@@ -32,7 +32,7 @@ Perfect to run on any single board computer with 4 cores and at least 512Mb of m
 <!--- header STOP from tools/include/markdown/HAS001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Home Automation → Home Assistant**
+Install from **[armbian-config](/config/) → Software → Home Automation → Home Assistant**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd HAS001

--- a/docs/software/homepage.md
+++ b/docs/software/homepage.md
@@ -38,7 +38,7 @@ Whether you're running a small homelab or a full server fleet, **gethomepage** o
 <!--- header STOP from tools/include/markdown/HPG001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → Homepage**
+Install from **[armbian-config](/config/) → Software → Management → Homepage**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd HPG001

--- a/docs/software/immich.md
+++ b/docs/software/immich.md
@@ -35,7 +35,7 @@ Thanks to Immich being built with modern technologies like NestJS, TypeScript, a
 <!--- header STOP from tools/include/markdown/IMM001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Immich**
+Install from **[armbian-config](/config/) → Software → Media → Immich**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd IMM001

--- a/docs/software/iperf3.md
+++ b/docs/software/iperf3.md
@@ -19,7 +19,7 @@ iperf3 bandwidth measuring tool
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://netbox.readthedocs.io/en/stable/) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8222`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Netconfig → iperf3**
+Install from **[armbian-config](/config/) → Software → Netconfig → iperf3**
 
 ~~~ custombash title="iperf3 bandwidth measuring tool"
 armbian-config --cmd IPR001

--- a/docs/software/iptraf-ng.md
+++ b/docs/software/iptraf-ng.md
@@ -19,7 +19,7 @@ iptraf-ng IP LAN monitor
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://netbox.readthedocs.io/en/stable/) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8222`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Netconfig → iptraf-ng**
+Install from **[armbian-config](/config/) → Software → Netconfig → iptraf-ng**
 
 ~~~ custombash title="iptraf-ng IP LAN monitor"
 armbian-config --cmd IPT001

--- a/docs/software/jellyfin.md
+++ b/docs/software/jellyfin.md
@@ -22,7 +22,7 @@ Jellyfin is a Free Software Media System that puts you in control of managing an
 <!--- header STOP from tools/include/markdown/JMS001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Jellyfin**
+Install from **[armbian-config](/config/) → Software → Media → Jellyfin**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd JMS001

--- a/docs/software/jellyseerr.md
+++ b/docs/software/jellyseerr.md
@@ -22,7 +22,7 @@ Jellyseerr is a free and open source software application for managing requests 
 <!--- header STOP from tools/include/markdown/JEL001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Jellyseerr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Jellyseerr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd JEL001

--- a/docs/software/lidarr.md
+++ b/docs/software/lidarr.md
@@ -22,7 +22,7 @@ Lidarr is a music collection manager for Usenet and BitTorrent users. It can mon
 <!--- header STOP from tools/include/markdown/LID001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Lidarr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Lidarr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd LID001

--- a/docs/software/mariadb.md
+++ b/docs/software/mariadb.md
@@ -25,7 +25,7 @@ MariaDB supports a wide range of storage engines, advanced SQL capabilities, and
 <!--- header STOP from tools/include/markdown/DAT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Database → Mariadb**
+Install from **[armbian-config](/config/) → Software → Database → Mariadb**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd DAT001

--- a/docs/software/medusa.md
+++ b/docs/software/medusa.md
@@ -22,7 +22,7 @@ Medusa is an automatic Video Library Manager for TV Shows. It watches for new ep
 <!--- header STOP from tools/include/markdown/MDS001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Medusa**
+Install from **[armbian-config](/config/) → Software → Downloaders → Medusa**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd MDS001

--- a/docs/software/mysql.md
+++ b/docs/software/mysql.md
@@ -22,7 +22,7 @@ MySQL is one of the world’s most widely used open-source database servers. Tru
 <!--- header STOP from tools/include/markdown/MYSQL1-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Database → MySQL**
+Install from **[armbian-config](/config/) → Software → Database → MySQL**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd MYSQL1

--- a/docs/software/navidrome.md
+++ b/docs/software/navidrome.md
@@ -22,7 +22,7 @@ Navidrome is a modern, lightweight, and self-hosted music server and streamer. I
 <!--- header STOP from tools/include/markdown/NAV001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Navidrome**
+Install from **[armbian-config](/config/) → Software → Media → Navidrome**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd NAV001

--- a/docs/software/netalertx.md
+++ b/docs/software/netalertx.md
@@ -40,7 +40,7 @@ For more information and installation guides, visit the official [NetAlertX docu
 <!--- header STOP from tools/include/markdown/NAX001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → NetAlertX**
+Install from **[armbian-config](/config/) → Software → Monitoring → NetAlertX**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd NAX001

--- a/docs/software/netbox.md
+++ b/docs/software/netbox.md
@@ -39,7 +39,7 @@ Originally developed by DigitalOcean, NetBox is widely adopted by network engine
 <!--- header STOP from tools/include/markdown/NBOX01-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → NetBox**
+Install from **[armbian-config](/config/) → Software → Management → NetBox**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd NBOX01

--- a/docs/software/netdata.md
+++ b/docs/software/netdata.md
@@ -22,7 +22,7 @@ Netdata is a partially open source tool designed to collect real-time metrics, s
 <!--- header STOP from tools/include/markdown/NTD001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → Netdata**
+Install from **[armbian-config](/config/) → Software → Monitoring → Netdata**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd NTD001

--- a/docs/software/nextcloud.md
+++ b/docs/software/nextcloud.md
@@ -22,7 +22,7 @@ Nextcloud gives you access to all your files wherever you are. Where are your ph
 <!--- header STOP from tools/include/markdown/NCT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Nextcloud**
+Install from **[armbian-config](/config/) → Software → Media → Nextcloud**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd NCT001

--- a/docs/software/nload.md
+++ b/docs/software/nload.md
@@ -19,7 +19,7 @@ realtime console network usage monitor
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://netbox.readthedocs.io/en/stable/) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8222`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Netconfig → nload**
+Install from **[armbian-config](/config/) → Software → Netconfig → nload**
 
 ~~~ custombash title="nload - realtime console network usage monitor"
 armbian-config --cmd NLD001

--- a/docs/software/octoprint.md
+++ b/docs/software/octoprint.md
@@ -21,7 +21,7 @@ OctoPrint is an open source 3D printer controller application, which provides a 
 <!--- header STOP from tools/include/markdown/OCT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Printing → OctoPrint**
+Install from **[armbian-config](/config/) → Software → Printing → OctoPrint**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd OCT001

--- a/docs/software/omv.md
+++ b/docs/software/omv.md
@@ -29,7 +29,7 @@ Whether used on a dedicated server, a Raspberry Pi, or virtualized hardware, OMV
 <!--- header STOP from tools/include/markdown/OMV001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → OMV**
+Install from **[armbian-config](/config/) → Software → Media → OMV**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd OMV001

--- a/docs/software/openhab.md
+++ b/docs/software/openhab.md
@@ -19,7 +19,7 @@ openHAB empowering the smart home
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> <span style="background-color:#fff3bf; color:#7c4d00; padding:3px 6px; border-radius:4px; font-size:90%;">armhf</span> · <span style="background-color:#ffffff; color:#039BE5; padding:3px 6px; border-radius:4px; font-size:90%;">🐳 Docker</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://www.openhab.org/docs/tutorial) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:2080`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Home Automation → openHAB**
+Install from **[armbian-config](/config/) → Software → Home Automation → openHAB**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd HAB001

--- a/docs/software/owncloud.md
+++ b/docs/software/owncloud.md
@@ -22,7 +22,7 @@ ownCloud is a free and open-source software project for content collaboration an
 <!--- header STOP from tools/include/markdown/OWC001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Owncloud**
+Install from **[armbian-config](/config/) → Software → Media → Owncloud**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd OWC001

--- a/docs/software/phpmyadmin.md
+++ b/docs/software/phpmyadmin.md
@@ -19,7 +19,7 @@ phpMyAdmin web interface manager
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#d3f9d8; color:#1b5e20; padding:3px 6px; border-radius:4px; font-size:90%;">arm64</span> · <span style="background-color:#ffffff; color:#039BE5; padding:3px 6px; border-radius:4px; font-size:90%;">🐳 Docker</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://www.phpmyadmin.net/docs/) · :material-lan-connect:{ title="Access port" } `http://<your.IP>:8071`
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Database → phpMyAdmin**
+Install from **[armbian-config](/config/) → Software → Database → phpMyAdmin**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd MYA001

--- a/docs/software/pi-hole.md
+++ b/docs/software/pi-hole.md
@@ -47,7 +47,7 @@ Pi-hole offers an effective and centralized way to enhance privacy and reduce un
 <!--- header STOP from tools/include/markdown/PIH001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → DNS → Pi-hole**
+Install from **[armbian-config](/config/) → Software → DNS → Pi-hole**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd PIH001

--- a/docs/software/portainer.md
+++ b/docs/software/portainer.md
@@ -22,7 +22,7 @@ Portainer simplifies your Docker container management via Portainer web interfac
 <!--- header STOP from tools/include/markdown/POR001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Containers → Portainer**
+Install from **[armbian-config](/config/) → Software → Containers → Portainer**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd POR001

--- a/docs/software/postgresql.md
+++ b/docs/software/postgresql.md
@@ -33,7 +33,7 @@ Thanks to its proven architecture and open-source nature, PostgreSQL fits seamle
 <!--- header STOP from tools/include/markdown/PGSQL1-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Database → PostgreSQL**
+Install from **[armbian-config](/config/) → Software → Database → PostgreSQL**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd PGSQL1

--- a/docs/software/prometheus.md
+++ b/docs/software/prometheus.md
@@ -22,7 +22,7 @@ Prometheus is an open-source monitoring and alerting toolkit designed for reliab
 <!--- header STOP from tools/include/markdown/PRO001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → Prometheus**
+Install from **[armbian-config](/config/) → Software → Monitoring → Prometheus**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd PRO001

--- a/docs/software/prowlarr.md
+++ b/docs/software/prowlarr.md
@@ -22,7 +22,7 @@ Prowlarr is a indexer manager/proxy built on the popular arr .net/reactjs base s
 <!--- header STOP from tools/include/markdown/PRW001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Prowlarr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Prowlarr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd PRW001

--- a/docs/software/proxmox-ve.md
+++ b/docs/software/proxmox-ve.md
@@ -37,7 +37,7 @@ Ideal for turning an Armbian board into a lightweight hypervisor without giving 
 <!--- header STOP from tools/include/markdown/PVE001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → Proxmox VE**
+Install from **[armbian-config](/config/) → Software → Management → Proxmox VE**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd PVE001

--- a/docs/software/qbittorrent.md
+++ b/docs/software/qbittorrent.md
@@ -22,7 +22,7 @@ The Qbittorrent⁠ project aims to provide an open-source software alternative t
 <!--- header STOP from tools/include/markdown/QBT001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → qBittorrent**
+Install from **[armbian-config](/config/) → Software → Downloaders → qBittorrent**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd QBT001

--- a/docs/software/radarr.md
+++ b/docs/software/radarr.md
@@ -22,7 +22,7 @@ Radarr - A fork of Sonarr to work with movies à la Couchpotato.
 <!--- header STOP from tools/include/markdown/RAD001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Radarr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Radarr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd RAD001

--- a/docs/software/redis.md
+++ b/docs/software/redis.md
@@ -32,7 +32,7 @@ Redis is widely used for real-time applications, caching layers, session stores,
 <!--- header STOP from tools/include/markdown/REDIS1-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Database → Redis**
+Install from **[armbian-config](/config/) → Software → Database → Redis**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd REDIS1

--- a/docs/software/rsyncd-server.md
+++ b/docs/software/rsyncd-server.md
@@ -16,7 +16,7 @@ comments: true
 :material-cpu-64-bit:{ title="Architecture" } <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">x86-64</span> <span style="background-color:#e0e0e0; color:#333333; padding:3px 6px; border-radius:4px; font-size:90%;">aarch64</span> <span style="background-color:#fff3bf; color:#7c4d00; padding:3px 6px; border-radius:4px; font-size:90%;">armhf</span> <span style="background-color:#f3d9fa; color:#6a1b9a; padding:3px 6px; border-radius:4px; font-size:90%;">riscv64</span> · :material-book-open-variant:{ title="Documentation" } [Documentation](https://forum.armbian.com/)
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Armbian → Rsyncd server**
+Install from **[armbian-config](/config/) → Software → Armbian → Rsyncd server**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd RSD001

--- a/docs/software/sabnzbd.md
+++ b/docs/software/sabnzbd.md
@@ -22,7 +22,7 @@ Sabnzbd⁠ makes Usenet as simple and streamlined as possible by automating ever
 <!--- header STOP from tools/include/markdown/SABN01-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → SABnzbd**
+Install from **[armbian-config](/config/) → Software → Downloaders → SABnzbd**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd SABN01

--- a/docs/software/samba.md
+++ b/docs/software/samba.md
@@ -22,7 +22,7 @@ Samba is an open-source software suite that enables seamless file and printer sh
 <!--- header STOP from tools/include/markdown/SMB001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → Samba**
+Install from **[armbian-config](/config/) → Software → Management → Samba**
 
 ~~~ custombash title="SAMBA Remote File share"
 armbian-config --cmd SMB001

--- a/docs/software/sonarr.md
+++ b/docs/software/sonarr.md
@@ -22,7 +22,7 @@ Sonarr (formerly NZBdrone) is a PVR for usenet and bittorrent users. It can moni
 <!--- header STOP from tools/include/markdown/SON001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Sonarr**
+Install from **[armbian-config](/config/) → Software → Downloaders → Sonarr**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd SON001

--- a/docs/software/stirling.md
+++ b/docs/software/stirling.md
@@ -22,7 +22,7 @@ Stirling-PDF is a robust, locally hosted web-based PDF manipulation tool using D
 <!--- header STOP from tools/include/markdown/STR001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Stirling**
+Install from **[armbian-config](/config/) → Software → Media → Stirling**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd STR001

--- a/docs/software/swag.md
+++ b/docs/software/swag.md
@@ -40,7 +40,7 @@ After entering required information, your server will have auto updating SSL sec
 <!--- header STOP from tools/include/markdown/SWAG01-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Web Hosting → SWAG**
+Install from **[armbian-config](/config/) → Software → Web Hosting → SWAG**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd SWAG01

--- a/docs/software/syncthing.md
+++ b/docs/software/syncthing.md
@@ -22,7 +22,7 @@ Syncthing replaces proprietary sync and cloud services with something open, trus
 <!--- header STOP from tools/include/markdown/STC001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Media → Syncthing**
+Install from **[armbian-config](/config/) → Software → Media → Syncthing**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd STC001

--- a/docs/software/transmission.md
+++ b/docs/software/transmission.md
@@ -22,7 +22,7 @@ Transmission⁠ is designed for easy, powerful use. Transmission has the feature
 <!--- header STOP from tools/include/markdown/TRA001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Downloaders → Transmission**
+Install from **[armbian-config](/config/) → Software → Downloaders → Transmission**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd TRA001

--- a/docs/software/unbound.md
+++ b/docs/software/unbound.md
@@ -21,7 +21,7 @@ Unbound is a high-performance, open-source DNS resolver. It primarily serves to 
 <!--- header STOP from tools/include/markdown/UNB001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → DNS → Unbound**
+Install from **[armbian-config](/config/) → Software → DNS → Unbound**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd UNB001

--- a/docs/software/uptime-kuma.md
+++ b/docs/software/uptime-kuma.md
@@ -25,7 +25,7 @@ You can receive instant notifications when a service goes down via Telegram, Dis
 <!--- header STOP from tools/include/markdown/UPK001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Monitoring → Uptime Kuma**
+Install from **[armbian-config](/config/) → Software → Monitoring → Uptime Kuma**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd UPK001

--- a/docs/software/wallos.md
+++ b/docs/software/wallos.md
@@ -92,7 +92,7 @@ This Docker-based application runs as a lightweight web service, providing an in
 <!--- header STOP from tools/include/markdown/WAL001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Finance → Wallos**
+Install from **[armbian-config](/config/) → Software → Finance → Wallos**
 
 ~~~ custombash title="CLI install"
 armbian-config --cmd WAL001

--- a/docs/software/webmin.md
+++ b/docs/software/webmin.md
@@ -22,7 +22,7 @@ Webmin is a web-based system administration tool for Unix-like servers. It provi
 <!--- header STOP from tools/include/markdown/WBM001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → Management → Webmin**
+Install from **[armbian-config](/config/) → Software → Management → Webmin**
 
 ~~~ custombash title="Webmin web-based management tool"
 armbian-config --cmd WBM001

--- a/docs/software/wireguard.md
+++ b/docs/software/wireguard.md
@@ -21,7 +21,7 @@ WireGuard is an extremely simple yet fast and modern VPN that utilizes state-of-
 <!--- header STOP from tools/include/markdown/WRG001-header.md --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → VPN → WireGuard**
+Install from **[armbian-config](/config/) → Software → VPN → WireGuard**
 
 ~~~ custombash title="WireGuard VPN server"
 armbian-config --cmd WRG001

--- a/docs/software/zerotier.md
+++ b/docs/software/zerotier.md
@@ -16,7 +16,7 @@ ZeroTier connect devices over your own private network in the world
 <!--- section image STOP from tools/include/images/ZTR001.png --->
 
 
-Install from **[armbian-config](/armbian-config/) → Software → VPN → ZeroTier**
+Install from **[armbian-config](/config/) → Software → VPN → ZeroTier**
 
 ~~~ custombash title="ZeroTier connect devices over your own private network in the world."
 armbian-config --cmd ZTR001

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,15 +79,9 @@ plugins:
         'User-Guide_Armbian-Config/System.md': 'config/index.md'
         'User-Guide_Armbian-Config/Network.md': 'config/network.md'
         'User-Guide_Armbian-Config/Localisation.md': 'config/localisation.md'
-        'armbian-config/index.md': 'config/index.md'
-        'armbian-config/kernel.md': 'config/kernel.md'
-        'armbian-config/desktops.md': 'config/desktops.md'
-        'armbian-config/storage.md': 'config/storage.md'
-        'armbian-config/access.md': 'config/access.md'
-        'armbian-config/user.md': 'config/user.md'
-        'armbian-config/updates.md': 'config/updates.md'
-        'armbian-config/network.md': 'config/network.md'
-        'armbian-config/localisation.md': 'config/localisation.md'
+        # Recovery was folded into Troubleshooting in March 2025; the nav
+        # section is still titled 'Troubleshooting and Recovery'.
+        'User-Guide_Recovery.md': 'User-Guide_Troubleshooting.md'
 #   - with-pdf:
 #       author: Armbian documentation team
 #       copyright: © 2024 by Armbian


### PR DESCRIPTION
Audit of every `.md` path that has ever existed under `docs/`, checked against the built site — and, crucially, against **how long each path was actually live**, measured from git.

Method: `git log --all --name-only -- docs/` → 353 historical paths → URL → probe the built site. Then `git log --diff-filter=A/D` per path for its lifetime. No path was guessed.

## Removed: the `/armbian-config/` redirects

That URL shape existed for **thirty minutes**:

```
a5719274  2026-08-23 22:48  docs: move armbian-config to short /armbian-config/ URLs
3ab2cd52  2026-08-23 23:18  docs: move armbian-config pages to /config/
```

It was never deployed, so nothing anywhere can link to it. All nine entries removed.

## The same measurement rules out four more candidate groups

A naive diff of the recent moves suggests these need redirects. Measuring their lifetimes says otherwise — every one of them is churn from the same evening or from a single day in 2024, and none was ever reachable:

| Candidate | Lifetime | Verdict |
|---|---|---|
| `armbian-config/*` (9 URLs) | 22:48 → 23:18, 2026-08-23 — **30 min** | removed |
| `User-Guide_Armbian-Config/{Kernel,Desktops,Storage,Access,User,Updates}/` (6) | 22:36 → 22:48, 2026-08-23 — **12 min** | not added |
| `User-Guide_Armbian-Config/*/*.user/` (40 generator fragments) | 2024-10-23 → 2024-10-24 — **1 day** | not added |
| `User-Guide_Armbian-Config/Software/` | 2024-10-23 → 2024-10-24 — **1 day** | not added |

## Added: the one real gap

`/User-Guide_Recovery/` → `/User-Guide_Troubleshooting/`

Live **2020-11-14 → 2025-03-19 — over four years** — and 404s today. Recovery was folded into Troubleshooting, whose nav section is still titled "Troubleshooting and Recovery" and still carries the commented-out `#- 'Recovery'` entry. Not a guess.

## Already covered — verified, unchanged

| Old path | Target |
|---|---|
| `Release_Changelog/` | `releases/` |
| `User-Guide_Armbian-Config/` | `config/` |
| `User-Guide_Armbian-Config/System/` | `config/` |
| `User-Guide_Armbian-Config/Network/` | `config/network/` |
| `User-Guide_Armbian-Config/Localisation/` | `config/localisation/` |
| `User-Guide_Allwinner_overlays/` | `User-Guide_Armbian_overlays/` |

## Software category pages need no redirect

All 19 `/User-Guide_Armbian-Software/<Category>/` URLs **still resolve 200**. `mkdocs.yml` keeps them built via `not_in_nav` precisely so they survive, and each now links out to the new `/software/<slug>/` pages. Redirecting a live, more-specific page to a less-specific overview would be a downgrade.

Per-app **anchors** (`…/Media/#jellyfin`) are gone, since categories no longer inline each app. Fragments cannot be redirected server-side; the reader lands on the right category page with the app linked one line down.

## Internal links updated

83 links in `docs/software/` (67) and `docs/User-Guide_Armbian-Software/` (16) read `[armbian-config](/armbian-config/)`. With the `/armbian-config/` redirects removed they would have broken, so this is now load-bearing rather than cosmetic.

Both trees are **generated** from `armbian/configng`, whose `tools/config-markdown.py` **already emits `/config/`** (lines 302, 411). The committed copies predate `3ab2cd52`. Refreshing them matches exactly what the next `pull-from-armbian-config` sync writes — this will not fight the generator, and **no configng change is needed**.

Zero `/armbian-config/` links remain in `docs/`.

## Old paths deliberately left unmapped

120 shipped paths still 404, all removed well before these moves and none with a defensible target: `docs/boards/*` (30), `docs/known_issues/*` (13), `docs/board_details/*` (8), `docs/Hardware_*` (11), `docs/webpage/*`, `Release_Download`, `User-Guide_Preface`, `Process_Merge-Policy`, plus ~30 `[Bracketed]-` and `_Underscored_` filenames from the 2016-era wiki import. Reported rather than invented, as asked. Happy to map any of them on request.

A further 21 paths appear in `git log --all` but only ever on unmerged PR branches (`/releases/25.11.1/`, and the intermediate Getting Started layouts) — never reachable, so no redirect is warranted.

## Verification

- `mkdocs build --strict` passes, no warnings.
- All 7 mapped old paths emit a redirect stub pointing at a page that exists.
- `/armbian-config/` is gone from the built site.
- Full crawl of the built site: **0 broken internal targets**.