### PR TITLE
index: drop the inline logo from the introduction page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,6 @@ image: /images/armbian-logo.png
 
 # Armbian OS
 
-![Armbian logo](images/logo-small.png){ width=25% }
-
 ## Preface
 
 Welcome to the official documentation of Armbian Linux, a highly optimized base operating system specialized for single board computers (*SBCs*) and its extensive build framework.


### PR DESCRIPTION
`docs/index.md` opened with a logo image in the page body. The theme already renders the logo in the header of every page, so this was the same thing twice — and it made the homepage inconsistent with the rest of the tree.

```diff
 # Armbian OS
 
-![Armbian logo](images/logo-small.png){ width=25% }
-
 ## Preface
```

## Verification

- **It was the only one.** `grep -rn '!\[Armbian logo\]\|logo-small\|logo_middle' docs --include='*.md'` returns exactly one hit — `docs/index.md:9`. No other page carries an inline logo, so removing it is a consistency fix rather than a one-off.
- **The logo is still visible.** `mkdocs.yml` sets `theme.logo: images/armbian-logo.png`; the built page still emits `md-header__button md-logo` with `src="images/armbian-logo.png"`.
- **`image:` front matter kept**, as asked — the built page still emits `<meta property="og:image" content="https://docs.armbian.com/images/armbian-logo.png">` and the `summary_large_image` card is unaffected.
- `mkdocs build --strict` passes, no warnings.

## Note on the asset

`docs/images/logo-small.png` is **not deleted**. After this change nothing in the repo references it, but images in this tree are hot-linked from `raw.githubusercontent.com` elsewhere — the Getting Started page does exactly that for its SD-card images — so removing the file could break links outside this repo. Say the word if you want it gone anyway.

Kept separate from #994 so the editorial table changes and this visual change can be reviewed and reverted independently. Both touch `docs/index.md` but in different sections; verified they merge cleanly together.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/998"><kbd><br> Open WWW preview <br></kbd></a>