### PR TITLE
getting-started: document flashing Qualcomm boards over EDL

### DIFF
--- a/docs/getting-started/writing-the-image.md
+++ b/docs/getting-started/writing-the-image.md
@@ -100,6 +100,48 @@ When a Rockchip device is placed into **Maskrom mode**, you can use `rkdevelopto
 6. Now you can flash the extracted image with `sudo rkdeveloptool wl 0 Armbian-YourBoard.img` (make sure the file ends with **.img**)
 7. Reboot your board with `sudo rkdeveloptool rd` which stands for (power) reset device
 
+### Qualcomm
+
+Qualcomm boards are flashed with **[Armbian Imager](https://github.com/armbian/imager/releases)** over
+**EDL** (Emergency Download Mode), so no extra tooling is needed. Imager writes
+straight to the board's built-in **eMMC** or **UFS**, depending on the board.
+
+Which boards can be flashed this way, which storage each one uses, and how each
+one enters EDL all come from the Armbian board registry, so the list grows
+without an Imager update. Boards covered so far include the **Arduino UNO Q**
+(QRB2210, eMMC) and the **Radxa Dragon** series &mdash; **Q6A** (QCS6490, UFS)
+and **Q8B** (SC8280XP, UFS).
+
+Steps:
+
+1. Put the board into **EDL mode**. Imager tells you which method your board
+   uses &mdash; either place the jumper on the **JCTL** pins, or hold the **EDL**
+   button while powering on.
+2. Connect the board to your computer with a USB cable.
+3. Open **Armbian Imager** and select your board and image.
+4. Flash. Imager uploads the firmware loader, then writes the partitions.
+
+!!! warning "UFS images are a separate download"
+
+    Boards that flash to UFS need an image built for UFS &mdash; its filename
+    carries a `-ufs` marker. An ordinary SD-card image will not boot from UFS.
+
+!!! question "Linux: `USB access denied`"
+
+    An EDL device appears as USB ID `05c6:9008`. Give your user access to it and
+    stop `qcserial` from claiming it first:
+
+    ``` bash
+    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="05c6", ATTR{idProduct}=="9008", MODE="0666"' | sudo tee /etc/udev/rules.d/51-qdl.rules
+    echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf
+    sudo udevadm control --reload-rules
+    ```
+
+!!! tip "`No EDL device found`"
+
+    The board is not in EDL mode, or the cable is data-only. Re-enter EDL mode as
+    in step 1, try a different USB cable or port, and reconnect.
+
 ---
 
 **Previous:** [Choosing an Armbian image](choosing-an-image.md)

--- a/docs/getting-started/writing-the-image.md
+++ b/docs/getting-started/writing-the-image.md
@@ -128,14 +128,31 @@ Steps:
 
 !!! question "Linux: `USB access denied`"
 
-    An EDL device appears as USB ID `05c6:9008`. Give your user access to it and
-    stop `qcserial` from claiming it first:
+    An EDL device appears as USB ID `05c6:9008`, and the in-tree `qcserial`
+    driver claims that same ID. Give your user access to the device and stop
+    `qcserial` from taking it:
 
     ``` bash
-    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="05c6", ATTR{idProduct}=="9008", MODE="0666"' | sudo tee /etc/udev/rules.d/51-qdl.rules
+    echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="05c6", ATTR{idProduct}=="9008", MODE="0660", GROUP="plugdev", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/51-qdl.rules
     echo 'blacklist qcserial' | sudo tee /etc/modprobe.d/blacklist-qcserial.conf
     sudo udevadm control --reload-rules
     ```
+
+    `uaccess` covers you when you are logged in at the machine itself; over SSH,
+    add yourself to `plugdev` with `sudo usermod -aG plugdev $USER` and log back
+    in.
+
+    The blacklist only stops `qcserial` loading in future &mdash; it does not
+    release a board it has already taken. If the module is loaded, unplug the
+    board, unload it, then plug the board back in:
+
+    ``` bash
+    sudo modprobe -r qcserial
+    ```
+
+    Reboot instead if it will not unload. Note that the blacklist is permanent
+    and also stops `qcserial` driving other Qualcomm serial devices, such as USB
+    modems; delete `/etc/modprobe.d/blacklist-qcserial.conf` to undo it.
 
 !!! tip "`No EDL device found`"
 

--- a/docs/getting-started/writing-the-image.md
+++ b/docs/getting-started/writing-the-image.md
@@ -102,7 +102,7 @@ When a Rockchip device is placed into **Maskrom mode**, you can use `rkdevelopto
 
 ### Qualcomm
 
-Qualcomm boards are flashed with **[Armbian Imager](https://github.com/armbian/imager/releases)** over
+Qualcomm boards are flashed with **[Armbian Imager](https://imager.armbian.com/)** over
 **EDL** (Emergency Download Mode), so no extra tooling is needed. Imager writes
 straight to the board's built-in **eMMC** or **UFS**, depending on the board.
 


### PR DESCRIPTION
`/getting-started/writing-the-image/#flash-to-internal-memory` covered Rockchip maskrom only. Qualcomm boards take a different route: **Armbian Imager** speaks QDL over **EDL** and writes the board's eMMC or UFS directly, so there is no separate tool to build the way `rkdeveloptool` needs.

Adds a **Qualcomm** subsection alongside the existing Rockchip one, covering EDL entry, flashing from Imager, the Linux udev / `qcserial` setup, and the "No EDL device found" case.

*(Split out of #997, which merged before this landed on it.)*

## Nothing here was written from memory

Every fact is taken from `armbian/imager`:

| Claim in the docs | Source |
|---|---|
| Jumper on **JCTL** pins, or hold the **EDL** button while powering on | `device.qdlInstructions` / `device.qdlInstructionsButton`, selected by `qdlInstructionsKey(edl_entry)` in `src/config/qdlBoards.ts` |
| udev rule + `blacklist qcserial` | `error.qdlPermissionDenied` — reproduced verbatim, split onto three lines for readability |
| "No EDL device found" | `device.qdlNotFound` |
| "uploads the firmware loader, then writes the partitions" | the `flash.qdlSahara` → `flash.qdlFirehose` progress steps |
| eMMC vs UFS per board | `QdlStorage::{Emmc,Ufs}` in `src-tauri/src/qdl/boards.rs` |
| `-ufs` filename marker | `UFS_MARKERS` in `src-tauri/src/qdl/mod.rs` |
| Registry is API-first, with a bundled fallback | doc comment on `src-tauri/src/qdl/boards.rs` |

## On the board list

`boards.rs` is explicitly *"used when the Armbian API carries no `qdl` block for a board … The API is the primary source."* So the section says the supported list comes from the board registry and **grows without an Imager release**, rather than pinning a list that goes stale.

The boards named are those with a registry entry today:

- **Arduino UNO Q** — QRB2210, eMMC *(bundled registry)*
- **Radxa Dragon Q6A** — QCS6490, UFS *(bundled registry)*
- **Radxa Dragon Q8B** — SC8280XP, UFS *(from `armbian/qcombin#3` and `armbian/armbian.github.io#354` in the 26.8 notes; not in the bundled fallback)*

## :warning: One thing I could not verify

I could not reach a live endpoint serving the `qdl` blocks — `api.armbian.com/api/v1/images/boards/` is the board-**photo** route and returns 404 for a board list. So the board naming above comes from source and release notes, **not** from the running registry.

If there is an endpoint that serves it, point me at it and I will confirm the names and add any boards I have missed.

## Verification

- `mkdocs build --strict` passes, no warnings.
- `#flash-to-internal-memory` and `#rockchip` anchors unchanged; the new section anchors at `#qualcomm`.
- Rendered output checked in the built page — admonitions, the three-line code block and the ordered list all render correctly.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/999"><kbd><br> Open WWW preview <br></kbd></a>