### PR TITLE
getting-started: link Armbian Imager to imager.armbian.com

### DIFF
--- a/docs/getting-started/choosing-an-image.md
+++ b/docs/getting-started/choosing-an-image.md
@@ -4,7 +4,7 @@ description: "Pick the right Armbian image for your board: Debian or Ubuntu, min
 ---
 # Choosing an image
 
-If your hardware is [supported](../index.md#which-hardware-is-supported), the recommended way to get started is to use **[Armbian Imager](https://github.com/armbian/imager/releases)** to select your board, download the appropriate image, and flash it in one step; alternatively, images can also be downloaded manually from [https://www.armbian.com/download/](https://www.armbian.com/download/) and flashed using Armbian Imager.
+If your hardware is [supported](../index.md#which-hardware-is-supported), the recommended way to get started is to use **[Armbian Imager](https://imager.armbian.com/)** to select your board, download the appropriate image, and flash it in one step; alternatively, images can also be downloaded manually from [https://www.armbian.com/download/](https://www.armbian.com/download/) and flashed using Armbian Imager.
 
 <!-- TODO: add some information about using the user interface on the site -->
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -9,7 +9,7 @@ Before you start, please make sure you have:
 - a proper power supply according to the board manufacturer's requirements <!-- TODO: link to power issues -->
 - a reliable SD card (at least 'Class 10' and 'A1'-rated is **highly** recommended)
 
-You will also need an existing operating system and an SD card writer tool. We recommend using **[Armbian Imager](https://github.com/armbian/imager/releases)** — the official Armbian flashing tool.
+You will also need an existing operating system and an SD card writer tool. We recommend using **[Armbian Imager](https://imager.armbian.com/)** — the official Armbian flashing tool.
 
 ![Armbian Imager workflow](../images/armbian-imager-ani.gif)
 

--- a/docs/getting-started/writing-the-image.md
+++ b/docs/getting-started/writing-the-image.md
@@ -8,7 +8,7 @@ There are multiple ways to deploy the image to your board. The easiest and most 
 
 ## Flash to SD Card
 
-Use **[Armbian Imager](https://github.com/armbian/imager/releases)** to flash the image.
+Use **[Armbian Imager](https://imager.armbian.com/)** to flash the image.
 
 Armbian Imager can:
 


### PR DESCRIPTION
The three places in Getting Started that recommend Armbian Imager sent the reader to the GitHub **releases list**. `https://imager.armbian.com/` is the project's own page for the tool — "Armbian Imager: Flash Armbian OS to SD & USB Drives", with the download and a walkthrough of the flow.

| File | Line |
|---|---|
| `docs/getting-started/index.md` | 12 — "We recommend using **Armbian Imager**" |
| `docs/getting-started/choosing-an-image.md` | 7 — "the recommended way to get started is to use **Armbian Imager**" |
| `docs/getting-started/writing-the-image.md` | 11 — "Use **Armbian Imager** to flash the image." |

## Scope

**Only the prose recommendations change.** `docs/releases/*.md` carries 105 `armbian/imager` references, but every one is a link to an individual pull request in a generated changelog (`armbian/imager#163`, …). Those must keep pointing at GitHub and are untouched — verified, the diff is 3 files / 3 lines.

The fourth occurrence, in the new Qualcomm section, is updated in #999 rather than here so that PR stays self-consistent. The two touch different lines of `writing-the-image.md` and merge cleanly.

## Verification

- `mkdocs build --strict` passes, no warnings.
- All three built pages emit exactly one `imager.armbian.com` link each.
- No `armbian/imager/releases` links remain anywhere under `docs/getting-started/`.
- `https://imager.armbian.com/` returns HTTP 200.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1000"><kbd><br> Open WWW preview <br></kbd></a>