### PR TITLE
releases: Armbian 26.8.3 release notes

### DIFF
--- a/docs/releases/26.8.md
+++ b/docs/releases/26.8.md
@@ -1,19 +1,19 @@
 ---
 title: Armbian 26.8.3
-description: "Armbian 26.8.3, released 23 August 2026: broad SoC enablement, CI migration to a dedicated repo on Debian Trixie, and a rewritten installer with UEFI ISOs."
+description: "Armbian 26.8.3, released 23 August 2026: broad platform modernization, restructured build and CI pipeline, and major installer and imager upgrades."
 ---
 
 # Armbian 26.8.3
 
 *Released 23 August 2026*
 
-This quarter's work centers on three dominant themes: **broad board and platform enablement** across Rockchip, Allwinner, TI, and Qualcomm SoCs; **a large-scale build and CI infrastructure migration** to a dedicated automation repository and a Debian Trixie host; and **a rewritten installer, a new Imager release, and UEFI ISO delivery** for cloud and virtual-media deployment.
+This cycle is defined by **broad platform modernization**, a **restructured build and CI pipeline**, and **substantial user-facing tooling improvements** across the installer, imager, and image output formats.
 
-Kernel and firmware stacks advanced across every major family. Mainline tracked through **7.1 stable and 7.2-rc series**, with Rockchip, Meson64, Sunxi, BCM2711, mvebu64, and i.MX6 families rebased onto current branches; U-Boot was bumped to **v2026.07 across dozens of boards**, and Rockchip vendor blobs (rkbin) were refreshed for RK3506, RK3528, RK3568, RK3576, and RV1106. New board additions include the **Anbernic RG DS and RG Vita Pro, Luckfox Nova, LubanCat 5IO, Milk-V DuoS, Avnet MaaXBoard 8ULP, SpacemiT K3 Pico-ITX, Radxa Dragon Q6A/Q8B, Xiaomi Pad 6S Pro, EASY EAI Nano, NanoPi NEO3 Plus, Walnut Pi, and Seeed reComputer RK3576/RK3588**, several of which were subsequently promoted to Supported. Out-of-tree wireless drivers (rtl8852bs, rtl8189es/fs, rtl8192eu, uwe5622) received substantial warning cleanups and kernel-7.2 compatibility work.
+Kernel and firmware baselines advanced across the tree, with mainline moving to **7.1 stable and 7.2-rc**, and edge branches bumped on rockchip64, meson64, mvebu64, sunxi, and bcm2711. U-Boot was refreshed to **v2026.04/07** on dozens of boards, including Rockchip RK35xx, Amlogic, i.MX6, mvebu Espressobin, and various SBCs. New board support spans Rockchip (Anbernic RG DS and RG Vita Pro, Luckfox Nova, LubanCat 5IO, KICKPI K3B, reComputer RK3576/RK3588, EASY EAI Nano, Graperain G3568 v2, Xiaomi Pad 6S Pro), Allwinner (Sovol Zero/SV08, Walnut Pi, Cubie A7Z, Orange Pi 4 Pro and Zero 3W, Tanix TX6S), SpacemiT (K3 Pico-ITX, Milk-V DuoS), NXP (Avnet MaaXBoard 8ULP), Qualcomm (Radxa Dragon Q6A/Q8B with UFS provisioning), and TI (BeagleBadge, TMDS64EVM). Wireless drivers received extensive cleanup, with **rtl8852bs, rtl8189es, rtl8192eu, and uwe5622** rebased into dedicated Armbian forks with 7.1/7.2 compatibility and thousands of compiler warnings eliminated.
 
-Build automation was consolidated into the new **armbian/ci repository**, taking over cronjobs, nightly, community, and stable release tracks from armbian/os, with introduction of a **watchdog for stalled runs, weekly Monday stable builds, and per-runner proxy, cache, and CPU-thread mapping** derived from NetBox. The official build host and default Docker image were migrated to **Debian Trixie**, with GCC 14/15 fallout addressed across U-Boot, i.MX8ULP libbpf, Realtek RTD1619B, and multiple Odroid targets; native riscv64 Docker images and a base-files-only workflow were added. Rockchip vendor U-Boot rebuilds, docker image tagging, and artifact hashing were hardened for parallel and cache-consistent execution.
+The build and CI infrastructure underwent a **structural migration from armbian/os to armbian/ci**, introducing self-hosted runner registration via NetBox, per-runner proxy and cache export, watchdog-based auto-retry for stalled jobs, and a weekly stable build cadence. The default build host and Docker base image moved to **Debian Trixie**, with native riscv64 image generation and GCC 13 cross toolchains for K3 R5 SPL. Kernel patch handling gained **parallel rewriting**, stricter From-header hygiene, and pinned source SHAs via `git_sources.json`.
 
-User-facing tooling saw **armbian-install redesigned as a tested armbian-config module** with SPI/MTD boot targets, standalone bootloader flashing, UEFI dual-boot diagnostics, and eMMC/NVMe split installs. **Armbian Imager 2.0** shipped with UFS flashing over EDL for Qualcomm boards, QDL board-registry integration, and hardened device enumeration on Windows and Linux. A new **image-output-iso extension** produces bootable live ISOs from UEFI images for cloud and IPMI virtual-CD workflows, with UEFI current, edge, and Debian Trixie cloud targets now published as ISO artifacts alongside standard image formats.
+User-facing changes center on a **redesigned armbian-install** delivered as a tested armbian-config module, with SPI/MTD boot targeting, split eMMC/NVMe flows, standalone bootloader flash, and clearer diagnostics for UEFI and dual-boot scenarios. **Armbian Imager 2.0** ships with QDL and UFS flashing for Qualcomm targets, board registry from the API, and hardened device enumeration on Windows and Linux. A new **image-output-iso extension** produces bootable live ISOs from UEFI images for cloud and IPMI virtual-CD deployment, and the download and redirector infrastructure was extended to carry ISO assets alongside compressed raw images.
 
 ## Board status changes
 
@@ -43,7 +43,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
 
 ## All changes
 
-??? abstract "782 merged pull requests in this release"
+??? abstract "787 merged pull requests in this release"
 
     ### Boards
 
@@ -175,6 +175,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     ### Kernel and U-Boot
 
     * Actions: Disable debugsym builds. by @vidplace7 in [armbian/MorseMicro-DKMS#7](https://github.com/armbian/MorseMicro-DKMS/pull/7)
+    * add 7.2 compatibility. by @EvilOlaf in [armbian/uwe5622#10](https://github.com/armbian/uwe5622/pull/10)
     * Add AX210 firmware a0-72. by @ginkage in [armbian/firmware#130](https://github.com/armbian/firmware/pull/130)
     * Add AYN Odin3 firmware. by @kasimling in [armbian/firmware#136](https://github.com/armbian/firmware/pull/136)
     * add compat for 7.2. by @EvilOlaf in [armbian/rtl8723ds#9](https://github.com/armbian/rtl8723ds/pull/9)
@@ -213,9 +214,11 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * bootscript: rk35xx: simplify armbianEnv.txt corruption detection. by @mingzhangqun in [armbian/build#9953](https://github.com/armbian/build/pull/9953)
     * brcm: add brcmfmac firmware aliases for easy-eai nano (rv1126). by @igorpecovnik in [armbian/firmware#133](https://github.com/armbian/firmware/pull/133)
     * bsp: use kernel version argument in ABL postinst scripts (fixes #10108). by @rorystandley in [armbian/build#10109](https://github.com/armbian/build/pull/10109)
+    * Build firmware paths with a single bounded snprintf. by @iav in [armbian/uwe5622#6](https://github.com/armbian/uwe5622/pull/6)
     * bump mainline to 7.1-rc7. by @EvilOlaf in [armbian/build#9950](https://github.com/armbian/build/pull/9950)
     * Bump/rk uboot swig fleet mkspi 2. by @redrathnure in [armbian/build#10122](https://github.com/armbian/build/pull/10122)
     * can: rockchip: add RK3588 CAN support (for kernel v6.18 / v7.1 / v7.2). by @lch08 in [armbian/build#10184](https://github.com/armbian/build/pull/10184)
+    * ci: keep the mirror schedule alive. by @igorpecovnik in [armbian/phytium-linux-kernel#1](https://github.com/armbian/phytium-linux-kernel/pull/1)
     * cix-acpi: bump `edge` to 7.1.y. by @EvilOlaf in [armbian/build#10167](https://github.com/armbian/build/pull/10167)
     * cix-p1: edge: update patches for 7.1.5, remove version pin. by @EvilOlaf in [armbian/build#10297](https://github.com/armbian/build/pull/10297)
     * cix-p1: pin edge kernel to v7.1.4 (Panthor patchset breaks on 7.1.5). by @igorpecovnik in [armbian/build#10282](https://github.com/armbian/build/pull/10282)
@@ -231,6 +234,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * drm/rockchip: dw-dp: ratelimit AUX timeout logging. by @SuperKali in [armbian/linux-rockchip#514](https://github.com/armbian/linux-rockchip/pull/514)
     * drm: rockchip: DSI fixes for RK3576 dual-display. by @mingzhangqun in [armbian/linux-rockchip#495](https://github.com/armbian/linux-rockchip/pull/495)
     * drm: rockchip: dw-dp: add AUX recovery for USB-C DP Alt Mode. by @mingzhangqun in [armbian/linux-rockchip#494](https://github.com/armbian/linux-rockchip/pull/494)
+    * Drop unused locals in sdiohal and cfg80211. by @iav in [armbian/uwe5622#14](https://github.com/armbian/uwe5622/pull/14)
     * easepi-r2/a2: fix device tree. by @jjm2473 in [armbian/linux-rockchip#491](https://github.com/armbian/linux-rockchip/pull/491)
     * Enable 1 GHz frequency for Panthor on mainline. by @ginkage in [armbian/build#10035](https://github.com/armbian/build/pull/10035)
     * Enable mainline kernel & u-boot on Avaota A1. by @juanesf in [armbian/build#10434](https://github.com/armbian/build/pull/10434)
@@ -239,6 +243,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * Feature/sunxi mainline stmmac ac300. by @deece in [armbian/build#9952](https://github.com/armbian/build/pull/9952)
     * firmware: novatek: add nt36532_n81a_fw_csot.bin for Xiaomi Pad 6S Pro. by @code002-2 in [armbian/firmware#139](https://github.com/armbian/firmware/pull/139)
     * Fix -Warray-bounds, -Wformat-truncation and -Wframe-larger-than (73/8/2 -> 0). by @iav in [armbian/wifi-rtl8852bs#19](https://github.com/armbian/wifi-rtl8852bs/pull/19)
+    * Fix -Wmissing-prototypes warnings (157 → 0). by @iav in [armbian/uwe5622#5](https://github.com/armbian/uwe5622/pull/5)
     * Fix -Wmissing-prototypes warnings across the driver (2179 → 42). by @iav in [armbian/wifi-rtl8852bs#7](https://github.com/armbian/wifi-rtl8852bs/pull/7)
     * Fix -Wunused-variable: 1545 -> 48 (DEBUG=n) / -> 4 (DEBUG=y). by @iav in [armbian/wifi-rtl8852bs#17](https://github.com/armbian/wifi-rtl8852bs/pull/17)
     * Fix build for Linux 7.1. by @EvilOlaf in [armbian/bcmdhd-dkms#7](https://github.com/armbian/bcmdhd-dkms/pull/7)
@@ -250,6 +255,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * fix Radxa U-Boot ITB dependency. by @yisding in [armbian/build#10196](https://github.com/armbian/build/pull/10196)
     * fix the hdmirx HPD patch against kernel6.18 & kernel 7.1. by @pdapandapda in [armbian/build#10180](https://github.com/armbian/build/pull/10180)
     * Fix two clang findings: sscanf %7s overflow in mp ioctl, uninitialised max_bw in rtw_vht. by @iav in [armbian/wifi-rtl8852bs#21](https://github.com/armbian/wifi-rtl8852bs/pull/21)
+    * Fix use-after-free in mtty_probe() error path. by @enromytase in [armbian/uwe5622#4](https://github.com/armbian/uwe5622/pull/4)
     * fix(mvebu-6.18): drop SysRq-via-BREAK patch, fixed upstream in 6.18.35. by @iav in [armbian/build#9958](https://github.com/armbian/build/pull/9958)
     * fix(patching): render patch summary tables at the reader's real terminal width. by @iav in [armbian/build#10262](https://github.com/armbian/build/pull/10262)
     * fix(rockchip64-6.18): drop 8250 DMA reopen patch, fixed upstream in 6.18.y. by @igorpecovnik in [armbian/build#10482](https://github.com/armbian/build/pull/10482)
@@ -261,6 +267,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * Fix: EasePi-A2 Boot & Ethernet on Vendor Kernel. by @ifroncy01 in [armbian/build#9946](https://github.com/armbian/build/pull/9946)
     * genio, nio-12l: bump to pure mainline v7.1.y + loadaddr fixes. by @rpardini in [armbian/build#10034](https://github.com/armbian/build/pull/10034)
     * genio: u-boot: mt8195 (nio-12l): update addr's map patch for large kernels/initrds. by @rpardini in [armbian/build#10039](https://github.com/armbian/build/pull/10039)
+    * gha: add test workflow based on armbian. by @EvilOlaf in [armbian/uwe5622#7](https://github.com/armbian/uwe5622/pull/7)
     * Guard config-disabled static helpers to silence -Wunused-function. by @iav in [armbian/wifi-rtl8852bs#9](https://github.com/armbian/wifi-rtl8852bs/pull/9)
     * H50 and T9 led , display and other overlays update. by @gpaesano in [armbian/build#10359](https://github.com/armbian/build/pull/10359)
     * hal_ld_file: compose the external parameter file path after the folder is known. by @iav in [armbian/wifi-rtl8852bs#25](https://github.com/armbian/wifi-rtl8852bs/pull/25)
@@ -309,6 +316,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * Meson64: Update Waveshare CM4-IO-BASE-B DTS and add emc2305 fixups for driver to BLEEDINGEDGE branch. by @pyavitz in [armbian/build#10169](https://github.com/armbian/build/pull/10169)
     * mixtile-blade3: edge: u-boot: fancy it up (lwIP, mbedTLS, efi, btrfs, etc). by @rpardini in [armbian/build#10234](https://github.com/armbian/build/pull/10234)
     * mixtile-edge2: u-boot: main: bump (generic) u-boot to v2026.07-rc5. by @rpardini in [armbian/build#10071](https://github.com/armbian/build/pull/10071)
+    * mtty: tty_alloc_driver returns ERR_PTR, not NULL. by @iav in [armbian/uwe5622#8](https://github.com/armbian/uwe5622/pull/8)
     * mvebu64: bump kernels — legacy 6.12, current 6.18, edge 7.1. by @igorpecovnik in [armbian/build#10338](https://github.com/armbian/build/pull/10338)
     * mvebu64: modernize EspressoBin/MacchiatoBin firmware (u-boot 2026.07 + TF-A 2.14.0 + A3720 fixes). by @igorpecovnik in [armbian/build#10213](https://github.com/armbian/build/pull/10213)
     * nanopi-r5s: u-boot: main: bump u-boot to v2026.07-rc5 + make it patch-less. by @rpardini in [armbian/build#10072](https://github.com/armbian/build/pull/10072)
@@ -339,6 +347,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * recore: fix ATF v2.8.0 build - drop -Wl, prefix from LD flag. by @igorpecovnik in [armbian/build#10100](https://github.com/armbian/build/pull/10100)
     * Refactor DVFS patch and clean up uwe5622 driver kernel configuration. by @EvilOlaf in [armbian/build#10316](https://github.com/armbian/build/pull/10316)
     * remove *bleedingedge* from all boards. by @EvilOlaf in [armbian/build#10016](https://github.com/armbian/build/pull/10016)
+    * Remove interaction with CPUFreq limits. by @EvilOlaf in [armbian/uwe5622#9](https://github.com/armbian/uwe5622/pull/9)
     * Remove unused static functions (-Wunused-function 140 -> 6). by @iav in [armbian/wifi-rtl8852bs#15](https://github.com/armbian/wifi-rtl8852bs/pull/15)
     * replace patch `From:` headers across the framework with something meaningful. by @EvilOlaf in [armbian/build#10472](https://github.com/armbian/build/pull/10472)
     * Revert "`odroidc2`: u-boot: use minimal patchset for v22.01 u-boot". by @ssilnicki-dev in [armbian/build#10265](https://github.com/armbian/build/pull/10265)
@@ -425,12 +434,19 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * uefidt-edge: add qcom x1e patches back. by @amazingfate in [armbian/build#10394](https://github.com/armbian/build/pull/10394)
     * uefidt: add cix mainline support. by @amazingfate in [armbian/build#10411](https://github.com/armbian/build/pull/10411)
     * uefidt: bump edge kernel to 7.1. by @igorpecovnik in [armbian/build#10373](https://github.com/armbian/build/pull/10373)
+    * unisocwifi: forward-declare struct sprdwl_intf in intf_ops.h. by @iav in [armbian/uwe5622#11](https://github.com/armbian/uwe5622/pull/11)
+    * unisocwifi: make pcie_addr_buffer::pcie_addr a flexible array member. by @iav in [armbian/uwe5622#16](https://github.com/armbian/uwe5622/pull/16)
+    * unisocwifi: map sm_state onto wifi_connection_state in llstat. by @iav in [armbian/uwe5622#12](https://github.com/armbian/uwe5622/pull/12)
+    * unisocwifi: mark the two intentional switch fall-throughs. by @iav in [armbian/uwe5622#15](https://github.com/armbian/uwe5622/pull/15)
     * Up rtw8822b to v30.20.0. by @farwayer in [armbian/firmware#135](https://github.com/armbian/firmware/pull/135)
     * Update MorseMicro suite to 1.17.9. by @vidplace7 in [armbian/MorseMicro-DKMS#8](https://github.com/armbian/MorseMicro-DKMS/pull/8)
     * Update odroidxu4-current to 6.6.143. by @belegdol in [armbian/build#10018](https://github.com/armbian/build/pull/10018)
     * Update odroidxu4-current to 6.6.151. by @belegdol in [armbian/build#10413](https://github.com/armbian/build/pull/10413)
+    * update readme. by @EvilOlaf in [armbian/uwe5622#2](https://github.com/armbian/uwe5622/pull/2)
     * uwe5622: bump commit hash, include Linux 7.2 support. by @EvilOlaf in [armbian/build#10348](https://github.com/armbian/build/pull/10348)
     * v4l2loopback-dkms: raise kernel skip cutoff from 6.12 to 7.2. by @igorpecovnik in [armbian/build#10490](https://github.com/armbian/build/pull/10490)
+    * wcn_boot: fix sdio_pub_int_init for the >=7.1 gpiod int_ap (GCC14 -Wint-conversion). by @igorpecovnik in [armbian/uwe5622#1](https://github.com/armbian/uwe5622/pull/1)
+    * wcn_boot: stop ordering-comparing the int_ap gpio_desc pointer. by @iav in [armbian/uwe5622#13](https://github.com/armbian/uwe5622/pull/13)
     * wireless drivers: bump rtl8189es pin, re-point rtl8723ds pin. by @iav in [armbian/build#10502](https://github.com/armbian/build/pull/10502)
     * wireless: eliminate -Wempty-body (239 -> 0), fix CONFIG_RTW_DEBUG=n build. by @iav in [armbian/wifi-rtl8852bs#11](https://github.com/armbian/wifi-rtl8852bs/pull/11)
     * wireless: fix h2cb_alloc PHL prototype enum type (-Wenum-conversion 143 -> 27). by @iav in [armbian/wifi-rtl8852bs#12](https://github.com/armbian/wifi-rtl8852bs/pull/12)
@@ -532,7 +548,6 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * ci: expose Framework build branch input on build-all. by @igorpecovnik in [armbian/ci#20](https://github.com/armbian/ci/pull/20)
     * ci: force a fresh Docker image pull on manual builds (default yes). by @igorpecovnik in [armbian/ci#30](https://github.com/armbian/ci/pull/30)
     * ci: ghcr login with builtin GITHUB_TOKEN, mirroring armbian/os. by @igorpecovnik in [armbian/ci#9](https://github.com/armbian/ci/pull/9)
-    * ci: keep the mirror schedule alive. by @igorpecovnik in [armbian/phytium-linux-kernel#1](https://github.com/armbian/phytium-linux-kernel/pull/1)
     * ci: label chunk jobs with hash-free matrix.name. by @igorpecovnik in [armbian/ci#17](https://github.com/armbian/ci/pull/17)
     * ci: make git-trees workflow resilient to network failures. by @rpardini in [armbian/shallow#7](https://github.com/armbian/shallow/pull/7)
     * ci: probe apt proxy before exporting it (drop stale entries). by @igorpecovnik in [armbian/ci#16](https://github.com/armbian/ci/pull/16)
@@ -569,6 +584,7 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * docker: split host deps into per-group apt layers in generated Dockerfile. by @rpardini in [armbian/build#9999](https://github.com/armbian/build/pull/9999)
     * docker: warn when buildx is missing, and reap leftover per-build images. by @iav in [armbian/build#10239](https://github.com/armbian/build/pull/10239)
     * docs: refresh README (AI-assisted). by @igorpecovnik in [armbian/ci#29](https://github.com/armbian/ci/pull/29)
+    * docs: refresh README (AI-assisted). by @igorpecovnik in [armbian/distribution#14](https://github.com/armbian/distribution/pull/14)
     * Drop testing-wireless-performance-test.yml. by @igorpecovnik in [armbian/armbian.github.io#350](https://github.com/armbian/armbian.github.io/pull/350)
     * extensions/nvidia: per-distro version detection + runtime auto-disable on no-GPU hosts. by @igorpecovnik in [armbian/build#9845](https://github.com/armbian/build/pull/9845)
     * extensions/radxa-aic8800: use local dir as download cache. by @rpardini in [armbian/build#10156](https://github.com/armbian/build/pull/10156)
@@ -597,7 +613,6 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * gha/chunks: export per-runner caches in images job. by @igorpecovnik in [armbian/os#472](https://github.com/armbian/os/pull/472)
     * gha: add retry and empty-result guard to NetBox server list step. by @igorpecovnik in [armbian/os#469](https://github.com/armbian/os/pull/469)
     * gha: add ssh/rsync timeouts to image upload so dead servers fail fast. by @igorpecovnik in [armbian/os#473](https://github.com/armbian/os/pull/473)
-    * gha: add test workflow based on armbian. by @EvilOlaf in [armbian/uwe5622#7](https://github.com/armbian/uwe5622/pull/7)
     * gha: disable build cronjobs (moved to armbian/ci). by @igorpecovnik in [armbian/os#482](https://github.com/armbian/os/pull/482)
     * gha: DOCKER_SKIP_UPDATE=no. by @rpardini in [armbian/os#476](https://github.com/armbian/os/pull/476)
     * git-ref2info: support gitproxy (git_cdn) source for Makefile version fetch. by @igorpecovnik in [armbian/build#10066](https://github.com/armbian/build/pull/10066)
@@ -704,15 +719,18 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * css: uniform app-page logo size (.app-logo). by @igorpecovnik in [armbian/documentation#981](https://github.com/armbian/documentation/pull/981)
     * deprecated various channels and helper service. by @EvilOlaf in [armbian/documentation#970](https://github.com/armbian/documentation/pull/970)
     * docs(git_cdn): add GCDN001 help header/footer markdown. by @igorpecovnik in [armbian/configng#939](https://github.com/armbian/configng/pull/939)
+    * docs(markdown): clean up the armbian-config section pages. by @igorpecovnik in [armbian/configng#995](https://github.com/armbian/configng/pull/995)
     * docs(markdown): emit per-app SEO pages + category link hubs. by @igorpecovnik in [armbian/configng#991](https://github.com/armbian/configng/pull/991)
+    * docs(markdown): point in-page armbian-config links at /config/. by @igorpecovnik in [armbian/configng#996](https://github.com/armbian/configng/pull/996)
     * docs(markdown): tag app-page logos with .app-logo for uniform sizing. by @igorpecovnik in [armbian/configng#993](https://github.com/armbian/configng/pull/993)
     * docs: add Datacenter access section (Netbird VPN + board access). by @igorpecovnik in [armbian/documentation#936](https://github.com/armbian/documentation/pull/936)
     * docs: document gitproxy GITHUB_MIRROR and GITPROXY_ADDRESS. by @igorpecovnik in [armbian/documentation#925](https://github.com/armbian/documentation/pull/925)
     * docs: document PREFER_NATIVE_ARMHF and enrich arm64-compat-vdso entry. by @iav in [armbian/documentation#921](https://github.com/armbian/documentation/pull/921)
     * docs: document the `show-extensions` build command. by @iav in [armbian/documentation#944](https://github.com/armbian/documentation/pull/944)
     * docs: exclude docs/README.md from mkdocs build. by @iav in [armbian/documentation#933](https://github.com/armbian/documentation/pull/933)
+    * docs: move armbian-config pages to /config/ (keep old URLs). by @igorpecovnik in [armbian/documentation#992](https://github.com/armbian/documentation/pull/992)
     * docs: official build host is Debian Trixie. by @igorpecovnik in [armbian/documentation#974](https://github.com/armbian/documentation/pull/974)
-    * docs: refresh README (AI-assisted). by @igorpecovnik in [armbian/distribution#14](https://github.com/armbian/distribution/pull/14)
+    * docs: split armbian-config System into per-subcategory pages. by @igorpecovnik in [armbian/documentation#989](https://github.com/armbian/documentation/pull/989)
     * docs: use unpinned python3-dev in setup instructions. by @igorpecovnik in [armbian/documentation#935](https://github.com/armbian/documentation/pull/935)
     * downloads: support the ISO image type. by @igorpecovnik in [armbian/website#40](https://github.com/armbian/website/pull/40)
     * Extensions-List: document the image-output-iso extension. by @igorpecovnik in [armbian/documentation#949](https://github.com/armbian/documentation/pull/949)
@@ -751,6 +769,8 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * module_cockpit: install UEFI firmware and default new x86 VMs to UEFI. by @igorpecovnik in [armbian/configng#969](https://github.com/armbian/configng/pull/969)
     * module_docker: install docker-buildx on distro-maintained installs. by @igorpecovnik in [armbian/configng#967](https://github.com/armbian/configng/pull/967)
     * module_proxmox: add Proxmox VE (Debian trixie), keep the Armbian kernel. by @igorpecovnik in [armbian/configng#965](https://github.com/armbian/configng/pull/965)
+    * nav: point Unit Test Status at the unit tests. by @igorpecovnik in [armbian/documentation#987](https://github.com/armbian/documentation/pull/987)
+    * pack-debian: publish loong64 in the apt repo architecture list. by @igorpecovnik in [armbian/scripts#93](https://github.com/armbian/scripts/pull/93)
     * Process_CI: fix broken release-target links (wrong branch + workflow name). by @igorpecovnik in [armbian/documentation#952](https://github.com/armbian/documentation/pull/952)
     * Process_CI: point automation docs at armbian/ci (armbian/os deprecated). by @igorpecovnik in [armbian/documentation#950](https://github.com/armbian/documentation/pull/950)
     * pull-mirrors: fix null mirror flags (rate-limited geoip) + show table in run summary. by @igorpecovnik in [armbian/documentation#956](https://github.com/armbian/documentation/pull/956)
@@ -767,7 +787,6 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * software: add git_cdn module (GitHub caching git+http proxy). by @igorpecovnik in [armbian/configng#938](https://github.com/armbian/configng/pull/938)
     * Surface armbian-sdk images with Code server logo. by @igorpecovnik in [armbian/imager#138](https://github.com/armbian/imager/pull/138)
     * Surface flash write failures instead of a blank error screen. by @SuperKali in [armbian/imager#150](https://github.com/armbian/imager/pull/150)
-    * update readme. by @EvilOlaf in [armbian/uwe5622#2](https://github.com/armbian/uwe5622/pull/2)
     * WifiPerformance: update infrastructure section to autotests framework. by @igorpecovnik in [armbian/documentation#931](https://github.com/armbian/documentation/pull/931)
     * 📣 Call for testers: new armbian-install. by @igorpecovnik in [armbian/build#10176](https://github.com/armbian/build/pull/10176)
 
@@ -775,7 +794,6 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
 
     * (#9400 P2a) Replace echo|tr/sed subshells with parameter expansion. by @iav in [armbian/build#9809](https://github.com/armbian/build/pull/9809)
     * (#9400 P2b) Replace echo|pipe subshells with here-strings/parameter expansion. by @iav in [armbian/build#9947](https://github.com/armbian/build/pull/9947)
-    * add 7.2 compatibility. by @EvilOlaf in [armbian/uwe5622#10](https://github.com/armbian/uwe5622/pull/10)
     * Add a BTRFS_CHECKSUM build switch for choosing the checksum algorithm. by @dlitz in [armbian/build#10288](https://github.com/armbian/build/pull/10288)
     * Add support for Xiaomi Pad 6S Pro (sheng). by @code002-2 in [armbian/build#9988](https://github.com/armbian/build/pull/9988)
     * arduino: fetch qcombin at image-build time, not config time. by @igorpecovnik in [armbian/build#10226](https://github.com/armbian/build/pull/10226)
@@ -784,23 +802,19 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * armbian-firstrun: use atomic write for armbianEnv.txt MAC randomization. by @mingzhangqun in [armbian/build#9937](https://github.com/armbian/build/pull/9937)
     * BeagleY - Fix small broken GRS Arcade Button Mapping. by @Grippy98 in [armbian/build#10360](https://github.com/armbian/build/pull/10360)
     * bluetooth-hciattach: only deploy the service on BSP (vendor/legacy) branches. by @defcom5-rockchip in [armbian/build#10410](https://github.com/armbian/build/pull/10410)
-    * Build firmware paths with a single bounded snprintf. by @iav in [armbian/uwe5622#6](https://github.com/armbian/uwe5622/pull/6)
     * compress-checksum: SKIP_COMPRESSING to leave chosen formats uncompressed. by @igorpecovnik in [armbian/build#10323](https://github.com/armbian/build/pull/10323)
     * drivers_network.sh remove version guards, rtl8723ds update hash & bind to family. by @EvilOlaf in [armbian/build#10353](https://github.com/armbian/build/pull/10353)
-    * Drop unused locals in sdiohal and cfg80211. by @iav in [armbian/uwe5622#14](https://github.com/armbian/uwe5622/pull/14)
     * easepi: normalize BOARD_VENDOR to lowercase 'linkease'. by @igorpecovnik in [armbian/build#10397](https://github.com/armbian/build/pull/10397)
     * Enable 1 GHz frequency for Panthor. by @ginkage in [armbian/build#10067](https://github.com/armbian/build/pull/10067)
     * Enable pwm gpio. by @frank-f in [armbian/build#10238](https://github.com/armbian/build/pull/10238)
     * fake-ubuntu-advantage-tools: provide ubuntu-pro-client. by @Grippy98 in [armbian/build#10116](https://github.com/armbian/build/pull/10116)
     * firstlogin: use useradd/groupadd instead of the adduser suite. by @igorpecovnik in [armbian/build#10127](https://github.com/armbian/build/pull/10127)
-    * Fix -Wmissing-prototypes warnings (157 → 0). by @iav in [armbian/uwe5622#5](https://github.com/armbian/uwe5622/pull/5)
     * Fix build with podman - no .Server.Arch. by @cfraz89 in [armbian/build#10438](https://github.com/armbian/build/pull/10438)
     * Fix Darwin Docker Host Arch. by @Grippy98 in [armbian/build#10279](https://github.com/armbian/build/pull/10279)
     * Fix ethernet on tx6s-axp-313. by @alnahian2011 in [armbian/build#10443](https://github.com/armbian/build/pull/10443)
     * Fix led trigger for nanopi 5s led-lan2. by @ruabmbua in [armbian/build#10028](https://github.com/armbian/build/pull/10028)
     * Fix swapfile creation. by @pierg75 in [armbian/build#10065](https://github.com/armbian/build/pull/10065)
     * Fix TI K3 Suite Matching for Ubuntu Hosts and Enable GPU Acceleration for BeagleBoards. by @Grippy98 in [armbian/build#10112](https://github.com/armbian/build/pull/10112)
-    * Fix use-after-free in mtty_probe() error path. by @enromytase in [armbian/uwe5622#4](https://github.com/armbian/uwe5622/pull/4)
     * fix(firstlogin): remove .not_logged_in_yet marker via EXIT trap. by @Mkiring in [armbian/build#10450](https://github.com/armbian/build/pull/10450)
     * fix(interactive): parse case alternatives in get_kernel_info_for_branch. by @iav in [armbian/build#9798](https://github.com/armbian/build/pull/9798)
     * fix(offline): honor OFFLINE_WORK in git-ref2info and memoize TTL. by @iav in [armbian/build#9797](https://github.com/armbian/build/pull/9797)
@@ -815,11 +829,8 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * k3: restore required edge platform drivers. by @Grippy98 in [armbian/build#10273](https://github.com/armbian/build/pull/10273)
     * loong64: migrate from debian-ports to the main Debian archive. by @igorpecovnik in [armbian/build#10404](https://github.com/armbian/build/pull/10404)
     * Milk-V Jupiter disable EEPROM node. by @pyavitz in [armbian/build#9944](https://github.com/armbian/build/pull/9944)
-    * mtty: tty_alloc_driver returns ERR_PTR, not NULL. by @iav in [armbian/uwe5622#8](https://github.com/armbian/uwe5622/pull/8)
     * Odin3 bringup. by @kasimling in [armbian/build#10229](https://github.com/armbian/build/pull/10229)
-    * pack-debian: publish loong64 in the apt repo architecture list. by @igorpecovnik in [armbian/scripts#93](https://github.com/armbian/scripts/pull/93)
     * recomputer: drop 'Devkit' from BOARD_NAME. by @igorpecovnik in [armbian/build#10256](https://github.com/armbian/build/pull/10256)
-    * Remove interaction with CPUFreq limits. by @EvilOlaf in [armbian/uwe5622#9](https://github.com/armbian/uwe5622/pull/9)
     * rootfs-image: move `pre_install_distribution_specific` inside `install_distribution_specific()`. by @rpardini in [armbian/build#10157](https://github.com/armbian/build/pull/10157)
     * rtl8192eu: fix -Wmissing-prototypes for 121 functions. by @iav in [armbian/build#9963](https://github.com/armbian/build/pull/9963)
     * rtl8192eu: fix build against 7.1 and re-enable. by @EvilOlaf in [armbian/build#10009](https://github.com/armbian/build/pull/10009)
@@ -830,17 +841,11 @@ User-facing tooling saw **armbian-install redesigned as a tested armbian-config 
     * shellfmt: run lib/tools/shellfmt.sh, no changes. by @rpardini in [armbian/build#10087](https://github.com/armbian/build/pull/10087)
     * stubble: add host dependencies. by @amazingfate in [armbian/build#10020](https://github.com/armbian/build/pull/10020)
     * stubble: only add host deps when KERNEL_DO_STUBBLE=yes. by @igorpecovnik in [armbian/build#10022](https://github.com/armbian/build/pull/10022)
-    * unisocwifi: forward-declare struct sprdwl_intf in intf_ops.h. by @iav in [armbian/uwe5622#11](https://github.com/armbian/uwe5622/pull/11)
-    * unisocwifi: make pcie_addr_buffer::pcie_addr a flexible array member. by @iav in [armbian/uwe5622#16](https://github.com/armbian/uwe5622/pull/16)
-    * unisocwifi: map sm_state onto wifi_connection_state in llstat. by @iav in [armbian/uwe5622#12](https://github.com/armbian/uwe5622/pull/12)
-    * unisocwifi: mark the two intentional switch fall-throughs. by @iav in [armbian/uwe5622#15](https://github.com/armbian/uwe5622/pull/15)
     * Update VERSION. by @EvilOlaf in [armbian/build#9938](https://github.com/armbian/build/pull/9938)
     * Use relative symbolic links for some BSP files. by @retro98boy in [armbian/build#10145](https://github.com/armbian/build/pull/10145)
     * uwe5622: bump driver commit. by @EvilOlaf in [armbian/build#10317](https://github.com/armbian/build/pull/10317)
     * uwe5622: fix -Wmissing-prototypes warnings (155 -> 2). by @iav in [armbian/build#9970](https://github.com/armbian/build/pull/9970)
     * uwe5622: source the driver from armbian/uwe5622 (incl. the >=7.1 gpiod fix). by @igorpecovnik in [armbian/build#10300](https://github.com/armbian/build/pull/10300)
     * uwe5622: switch to unified driver in dedicated repo. by @EvilOlaf in [armbian/build#10113](https://github.com/armbian/build/pull/10113)
-    * wcn_boot: fix sdio_pub_int_init for the >=7.1 gpiod int_ap (GCC14 -Wint-conversion). by @igorpecovnik in [armbian/uwe5622#1](https://github.com/armbian/uwe5622/pull/1)
-    * wcn_boot: stop ordering-comparing the int_ap gpio_desc pointer. by @iav in [armbian/uwe5622#13](https://github.com/armbian/uwe5622/pull/13)
     * wifi: rtw88: sdio: Fix unhandled RX request interrupt storm. by @deece in [armbian/build#10121](https://github.com/armbian/build/pull/10121)
     * youyeetoo-r1: fix M.2 PCIe reset gpio. by @SuperKali in [armbian/build#10469](https://github.com/armbian/build/pull/10469)

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,7 +9,7 @@ Notes for each Armbian stable release, newest first. Each page carries the relea
 
 * **[Armbian 26.8.3](26.8.md)** &mdash; 23 August 2026
 
-    Armbian 26.8.3, released 23 August 2026: broad SoC enablement, CI migration to a dedicated repo on Debian Trixie, and a rewritten installer with UEFI ISOs.
+    Armbian 26.8.3, released 23 August 2026: broad platform modernization, restructured build and CI pipeline, and major installer and imager upgrades.
 
 * **[Armbian 26.5.1](26.5.md)** &mdash; 29 May 2026
 


### PR DESCRIPTION
Generated by [Reporting: Release summary](https://github.com/armbian/armbian.github.io/actions/workflows/reporting-release-summary.yml)
for Armbian 26.8.3, from the pull requests
merged across the org in the release window.

This page is the canonical release note. The quarterly digest is no
longer published as a GitHub release, because GitHub serves release
pages `noindex` and this one has to be findable.

The narrative body, the change list and the board status changes all
come from PR metadata and the digest; nothing here is hand-written.

Re-running the workflow for this version updates this PR in place.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1001"><kbd><br> Open WWW preview <br></kbd></a>