### PR TITLE
SEO: keyword-rich page titles (seo_title override)

### DIFF
--- a/docs/Board_Maintainers_Procedures_and_Guidelines.md
+++ b/docs/Board_Maintainers_Procedures_and_Guidelines.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian board maintainer procedures & guidelines"
 description: "Armbian board maintainer procedures and guidelines: requirements, responsibilities and expectations for maintaining single-board computer support in Armbian."
 ---
 

--- a/docs/Community_Forums.md
+++ b/docs/Community_Forums.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian community forums & SBC support"
 description: "Armbian community forums at forum.armbian.com for single-board computer support, troubleshooting help, project discussion and connecting with other users."
 ---
 

--- a/docs/Community_Github.md
+++ b/docs/Community_Github.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian GitHub repositories: build, config & OS"
 description: "Main Armbian GitHub repositories: the build framework, the armbian-config configuration utility and the Armbian OS assembly line for rolling and point releases."
 ---
 

--- a/docs/Community_IRC.md
+++ b/docs/Community_IRC.md
@@ -1,5 +1,6 @@
 ---
 title: Armbian Social Media Channels
+seo_title: "Armbian IRC, Discord & social media channels"
 description: Social media channels maintained by Armbian project team
 ---
 

--- a/docs/Contribute/Armbian-config.md
+++ b/docs/Contribute/Armbian-config.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Add software to armbian-config: install modules"
 description: "Add a new software title to armbian-config: test the install manually, clone configng, design the JSON menu and write the install and uninstall module."
 ---
 

--- a/docs/Contribute/Datacenter.md
+++ b/docs/Contribute/Datacenter.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian Datacenter access for board maintainers"
 description: "Access the Armbian Datacenter hardware lab: request board-maintainers GitHub team membership and connect over VPN to debug and test boards on real hardware."
 ---
 

--- a/docs/Developer-Guide_Adding-Board-Family.md
+++ b/docs/Developer-Guide_Adding-Board-Family.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian: add a new board or board family"
 description: "Add a new board or board family to the Armbian build framework, with example pull requests showing the config and patch changes needed for ARM SBCs."
 ---
 

--- a/docs/Developer-Guide_Build-Commands.md
+++ b/docs/Developer-Guide_Build-Commands.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build commands for compile.sh"
 description: "Armbian build framework commands for compile.sh: build the kernel, run kernel-config menuconfig, rewrite the kernel config, check device trees and more."
 ---
 

--- a/docs/Developer-Guide_Build-Preparation.md
+++ b/docs/Developer-Guide_Build-Preparation.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build host setup & requirements"
 description: "Armbian build framework quick start: hardware requirements, Debian 13 Trixie or Docker host setup and cloning the repository to build ARM Linux images."
 ---
 

--- a/docs/Developer-Guide_Build-Switches.md
+++ b/docs/Developer-Guide_Build-Switches.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build switches: BOARD, BRANCH & RELEASE"
 description: "Armbian build framework switches for compile.sh: BOARD, BRANCH, RELEASE and other optional parameters to customize kernel, U-Boot and image builds."
 ---
 

--- a/docs/Developer-Guide_Building-with-Docker.md
+++ b/docs/Developer-Guide_Building-with-Docker.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build with Docker: images & kernels"
 description: "Build Armbian images, kernels and U-Boot packages with Docker, the officially supported containerized method, including requirements and privileged-mode setup."
 ---
 

--- a/docs/Developer-Guide_Building-with-Multipass.md
+++ b/docs/Developer-Guide_Building-with-Multipass.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build with Multipass Ubuntu VM"
 description: "Build Armbian images in a Multipass Ubuntu VM: provision the instance, clone the build repository and run compile.sh on macOS, Windows or Linux."
 ---
 

--- a/docs/Developer-Guide_Desktops.md
+++ b/docs/Developer-Guide_Desktops.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian desktops: armbian-config developer guide"
 description: "Armbian desktop submodule reference for armbian-config: YAML-driven install pipeline, tiered minimal, mid and full desktops, auto-login and package overrides."
 ---
 

--- a/docs/Developer-Guide_Extension-ccache-remote.md
+++ b/docs/Developer-Guide_Extension-ccache-remote.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian ccache-remote extension for faster builds"
 description: "Armbian ccache-remote extension: share a remote ccache across build hosts using Redis or HTTP WebDAV to speed up repeated kernel and U-Boot compilation."
 ---
 

--- a/docs/Developer-Guide_Extension-kernel-rust.md
+++ b/docs/Developer-Guide_Extension-kernel-rust.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian kernel-rust extension: build Rust modules"
 description: "Armbian kernel-rust extension: enable CONFIG_RUST and install a pinned rustup toolchain to build Rust kernel modules alongside C in Armbian ARM kernels."
 ---
 

--- a/docs/Developer-Guide_Extensions-Hooks.md
+++ b/docs/Developer-Guide_Extensions-Hooks.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build extension hooks reference"
 description: "Reference of Armbian build framework extension hooks in call order, such as post_family_config and user_config, for customizing the ARM image build."
 ---
 

--- a/docs/Developer-Guide_Extensions-List.md
+++ b/docs/Developer-Guide_Extensions-List.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build extensions list & ENABLE_EXTENSIONS"
 description: "Alphabetical reference of official Armbian build framework extensions, how to enable them with ENABLE_EXTENSIONS, and their key parameters and descriptions."
 ---
 

--- a/docs/Developer-Guide_Extensions.md
+++ b/docs/Developer-Guide_Extensions.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build extensions framework & hooks"
 description: "Armbian build framework extensions: extend the build with Bash hooks and extension methods without overloading the core, plus terminology and examples."
 ---
 

--- a/docs/Developer-Guide_Overview.md
+++ b/docs/Developer-Guide_Overview.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build framework overview"
 description: "Overview of the Armbian build framework: build custom kernels, bootloaders and Debian or Ubuntu images for low-resource ARM single-board computers."
 ---
 

--- a/docs/Developer-Guide_User-Configurations.md
+++ b/docs/Developer-Guide_User-Configurations.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian userpatches: custom patches & config files"
 description: "Customize Armbian builds with userpatches: add kernel and U-Boot patches, config files, first-boot presets and hooks without editing the core build script."
 ---
 

--- a/docs/Developer-Guide_Welcome.md
+++ b/docs/Developer-Guide_Welcome.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian build framework: compile.sh CLI intro"
 description: "Armbian build framework introduction: compile.sh command-line syntax, config files, logging and artifact caching for building custom ARM Linux images."
 ---
 

--- a/docs/Development-Code_Review_Procedures_and_Guidelines.md
+++ b/docs/Development-Code_Review_Procedures_and_Guidelines.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian code review procedures & guidelines"
 description: "Armbian development code review procedures and guidelines: who can review, approve and merge pull requests, and the requirements expected of contributors."
 ---
 

--- a/docs/Mirrors.md
+++ b/docs/Mirrors.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian mirror system & how to add a mirror"
 description: "How the Armbian mirror system works: a redirector routes downloads to the fastest nearby mirror, plus mirror specs and steps to contribute a new server."
 comments: true
 ---

--- a/docs/Process_Armbian-Task-Tracking.md
+++ b/docs/Process_Armbian-Task-Tracking.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian task tracking: GitHub issues & forum"
 description: "Armbian task tracking process: create a GitHub issue for code-related tasks and keep all discussion in a matching forum topic named by the issue ID."
 ---
 

--- a/docs/Process_CI.md
+++ b/docs/Process_CI.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian release automation & CI pipeline"
 description: "Armbian release automation and CI: how image build lists, recommended targets and download-page publishing are generated from the armbian/ci pipeline."
 ---
 

--- a/docs/Process_Contribute.md
+++ b/docs/Process_Contribute.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian contributing: fork & pull requests"
 description: "Contribute to Armbian on GitHub: fork the build, configng or documentation repositories, open issues and submit pull requests to the ARM Linux project."
 ---
 

--- a/docs/Process_Managing_Workflow.md
+++ b/docs/Process_Managing_Workflow.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian development workflow in Jira"
 description: "Managing the Armbian development workflow in Jira: epics, stories, tasks and bugs, fix versions and the upcoming-release Kanban board for prioritizing work."
 ---
 

--- a/docs/Quick_facts.md
+++ b/docs/Quick_facts.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian Linux: quick facts, mission & benefits"
 description: "Quick facts about Armbian Linux: optimized Debian and Ubuntu images for 100+ ARM single-board computers, the project's mission, challenges and key benefits."
 ---
 

--- a/docs/Release_Board-Maintainers.md
+++ b/docs/Release_Board-Maintainers.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Become an Armbian board maintainer"
 description: "Become an Armbian board maintainer: application steps, requirements and release responsibilities for testing and signing off single-board computer images."
 ---
 

--- a/docs/User-Guide_Advanced-Configuration.md
+++ b/docs/User-Guide_Advanced-Configuration.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian advanced config: keyboard, locale & language"
 description: "Armbian advanced configuration for single-board computers: change keyboard layout, system language and locales via armbian-config or Debian and Ubuntu tools."
 ---
 

--- a/docs/User-Guide_Armbian-Software/Armbian.md
+++ b/docs/User-Guide_Armbian-Software/Armbian.md
@@ -1,5 +1,6 @@
 ---
 title: "Armbian"
+seo_title: "Armbian apps for Armbian"
 description: "Armbian infrastructure services for Armbian on ARM64 and x86 single-board computers: CDN router, GH runners, Rsyncd server."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Backup.md
+++ b/docs/User-Guide_Armbian-Software/Backup.md
@@ -1,5 +1,6 @@
 ---
 title: "Backup"
+seo_title: "Backup apps for Armbian"
 description: "Backup solutions for your data for Armbian on ARM64 and x86 single-board computers: Duplicati."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Containers.md
+++ b/docs/User-Guide_Armbian-Software/Containers.md
@@ -1,5 +1,6 @@
 ---
 title: "Containers"
+seo_title: "Containers apps for Armbian"
 description: "Docker containerization and KVM virtual machines for Armbian on ARM64 and x86 single-board computers: Docker, Portainer."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/DNS.md
+++ b/docs/User-Guide_Armbian-Software/DNS.md
@@ -1,5 +1,6 @@
 ---
 title: "DNS"
+seo_title: "DNS apps for Armbian"
 description: "Network-wide ad blockers servers for Armbian on ARM64 and x86 single-board computers: AdGuardHome, Pi-hole, Unbound."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Database.md
+++ b/docs/User-Guide_Armbian-Software/Database.md
@@ -1,5 +1,6 @@
 ---
 title: "Database"
+seo_title: "Database apps for Armbian"
 description: "SQL database servers and web interface managers for Armbian on ARM64 and x86 single-board computers: MySQL, Mariadb, phpMyAdmin, PostgreSQL, Redis."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/DevTools.md
+++ b/docs/User-Guide_Armbian-Software/DevTools.md
@@ -1,5 +1,6 @@
 ---
 title: "Dev Tools"
+seo_title: "Dev Tools apps for Armbian"
 description: "Applications and tools for development for Armbian on ARM64 and x86 single-board computers: Git CLI, Code-server."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Downloaders.md
+++ b/docs/User-Guide_Armbian-Software/Downloaders.md
@@ -1,5 +1,6 @@
 ---
 title: "Downloaders"
+seo_title: "Downloaders apps for Armbian"
 description: "Download apps for movies, TV shows, music and subtitles for Armbian on ARM64 and x86 single-board computers: Bazarr, Deluge, qBittorrent, Prowlarr, Jellyseerr, Lidarr, Medusa, Rada"
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Finance.md
+++ b/docs/User-Guide_Armbian-Software/Finance.md
@@ -1,5 +1,6 @@
 ---
 title: "Finance"
+seo_title: "Finance apps for Armbian"
 description: "Manage your finances for Armbian on ARM64 and x86 single-board computers: Actual Budget, Wallos."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/HomeAutomation.md
+++ b/docs/User-Guide_Armbian-Software/HomeAutomation.md
@@ -1,5 +1,6 @@
 ---
 title: "Home Automation"
+seo_title: "Home Automation apps for Armbian"
 description: "Home Automation for control home appliances for Armbian on ARM64 and x86 single-board computers: Domoticz, EVCC, openHAB, Home Assistant."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Management.md
+++ b/docs/User-Guide_Armbian-Software/Management.md
@@ -1,5 +1,6 @@
 ---
 title: "Management"
+seo_title: "Management apps for Armbian"
 description: "Remote File & Management tools for Armbian on ARM64 and x86 single-board computers: Cockpit, Proxmox VE, Homepage, NetBox, apt-cacher-ng, git_cdn, Samba, Webmin."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Media.md
+++ b/docs/User-Guide_Armbian-Software/Media.md
@@ -1,5 +1,6 @@
 ---
 title: "Media"
+seo_title: "Media apps for Armbian"
 description: "Media servers, organizers and editors for Armbian on ARM64 and x86 single-board computers: Emby, Filebrowser, Hastebin, Immich, Jellyfin, Navidrome, Nextcloud, OMV, Owncloud, Synct"
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Monitoring.md
+++ b/docs/User-Guide_Armbian-Software/Monitoring.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring"
+seo_title: "Monitoring apps for Armbian"
 description: "Real-time monitoring, collecting metrics, up-time status for Armbian on ARM64 and x86 single-board computers: Grafana, NetAlertX, Netdata, Prometheus, Uptime Kuma, Dozzle."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Netconfig.md
+++ b/docs/User-Guide_Armbian-Software/Netconfig.md
@@ -1,5 +1,6 @@
 ---
 title: "Netconfig"
+seo_title: "Netconfig apps for Armbian"
 description: "Console network tools for measuring load and bandwidth for Armbian on ARM64 and x86 single-board computers: avahi-daemon, iperf3, iptraf-ng, nload."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Printing.md
+++ b/docs/User-Guide_Armbian-Software/Printing.md
@@ -1,5 +1,6 @@
 ---
 title: "Printing"
+seo_title: "Printing apps for Armbian"
 description: "Tools for printing and 3D printing for Armbian on ARM64 and x86 single-board computers: OctoPrint."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/Software.md
+++ b/docs/User-Guide_Armbian-Software/Software.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Install apps & services on Armbian"
 description: "Browse and install third-party applications and services on Armbian single-board computers with armbian-config, as Docker containers or native packages."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/VPN.md
+++ b/docs/User-Guide_Armbian-Software/VPN.md
@@ -1,5 +1,6 @@
 ---
 title: "VPN"
+seo_title: "VPN apps for Armbian"
 description: "Virtual Private Network tools for Armbian on ARM64 and x86 single-board computers: WireGuard, ZeroTier."
 comments: true
 ---

--- a/docs/User-Guide_Armbian-Software/WebHosting.md
+++ b/docs/User-Guide_Armbian-Software/WebHosting.md
@@ -1,5 +1,6 @@
 ---
 title: "Web Hosting"
+seo_title: "Web Hosting apps for Armbian"
 description: "Web server, LEMP, reverse proxy, Let's Encrypt SSL for Armbian on ARM64 and x86 single-board computers: SWAG, Ghost."
 comments: true
 ---

--- a/docs/User-Guide_Armbian_overlays.md
+++ b/docs/User-Guide_Armbian_overlays.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian device tree overlays: SPI, I2C & UART"
 description: "Enable Armbian Device Tree overlays on single-board computers to activate SPI, I2C, I2S, UART and GPIO interfaces via armbianEnv.txt or custom DTS files."
 ---
 

--- a/docs/User-Guide_Autoconfig.md
+++ b/docs/User-Guide_Autoconfig.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian first boot config: preset password, IP & Wi-Fi"
 description: "Automate Armbian first boot on single-board computers: preset root password, IP address and Wi-Fi via the .not_logged_in_yet file or a remote config."
 ---
 

--- a/docs/User-Guide_Board-Support-Rules.md
+++ b/docs/User-Guide_Board-Support-Rules.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian board support levels & maintainer rules"
 description: "Armbian board support rules and levels for single-board computers: Platinum, Standard and community-maintained tiers, their benefits and maintainer criteria."
 comments: true
 ---

--- a/docs/User-Guide_FAQ.md
+++ b/docs/User-Guide_FAQ.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian FAQ: boards, images & support"
 description: "Armbian FAQ: what Armbian is, why there is no universal image, board support statuses like WIP, CSC and EOS, and how this Debian and Ubuntu SBC distro works."
 ---
 

--- a/docs/User-Guide_Networking.md
+++ b/docs/User-Guide_Networking.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian networking: static IP, Wi-Fi & Netplan"
 description: "Configure Armbian networking on single-board computers with Netplan, systemd-networkd and NetworkManager, including static IP addresses and DHCP examples."
 ---
 

--- a/docs/User-Guide_Troubleshooting.md
+++ b/docs/User-Guide_Troubleshooting.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian troubleshooting: boot, power & SD card issues"
 description: "Armbian hardware troubleshooting for single-board computers: diagnose boot failures, freezes, crashes and USB issues caused by power supply or SD card problems."
 ---
 

--- a/docs/WifiPerformance.md
+++ b/docs/WifiPerformance.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian Wi-Fi adapter performance benchmarks"
 description: "Armbian WiFi performance benchmarks: throughput of USB, SDIO and PCI wireless adapters on single-board computers, tested in the Armbian autotests lab."
 comments: true
 ---

--- a/docs/config/access.md
+++ b/docs/config/access.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian SSH daemon & 2FA remote access"
 description: "Manage the SSH daemon, harden remote access and enable two-factor authentication (2FA) on Armbian single-board computers with armbian-config."
 comments: true
 ---

--- a/docs/config/desktops.md
+++ b/docs/config/desktops.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Install a desktop environment on Armbian"
 description: "Install, remove and configure desktop environments such as GNOME, KDE and XFCE on Armbian single-board computers with the armbian-config utility."
 comments: true
 ---

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "armbian-config: setup tool for your SBC"
 description: "armbian-config is the interactive, scriptable setup tool preinstalled on every Armbian image: configure networking, kernels, storage, users and software on your SBC."
 ---
 

--- a/docs/config/kernel.md
+++ b/docs/config/kernel.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian kernels, headers & device-tree overlays"
 description: "Switch kernels, install headers and manage device-tree overlays and the boot environment on Armbian single-board computers with armbian-config."
 comments: true
 ---

--- a/docs/config/localisation.md
+++ b/docs/config/localisation.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian timezone, locale & keyboard"
 description: "Set the timezone, system locale, language, keyboard layout and hostname on Armbian single-board computers with the armbian-config utility."
 comments: true
 ---

--- a/docs/config/network.md
+++ b/docs/config/network.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian networking: Wi-Fi & static IP"
 description: "Configure wired and wireless networking on Armbian: Wi-Fi, static IP, DHCP and advanced bridged setups on single-board computers with armbian-config."
 comments: true
 ---

--- a/docs/config/storage.md
+++ b/docs/config/storage.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian storage setup: eMMC, ZFS, NFS"
 description: "Install Armbian to eMMC, SATA or NVMe and set up ZFS, NFS and a read-only root filesystem on single-board computers using armbian-config."
 comments: true
 ---

--- a/docs/config/updates.md
+++ b/docs/config/updates.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Update & upgrade Armbian"
 description: "Apply OS updates and run Debian and Ubuntu distribution upgrades on Armbian single-board computers with the armbian-config utility."
 comments: true
 ---

--- a/docs/config/user.md
+++ b/docs/config/user.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian login shell & MOTD settings"
 description: "Change the default login shell and customise the MOTD login banner on Armbian single-board computers with the armbian-config utility."
 comments: true
 ---

--- a/docs/getting-started/first-boot-and-login.md
+++ b/docs/getting-started/first-boot-and-login.md
@@ -1,5 +1,6 @@
 ---
 title: First boot and login
+seo_title: "First boot & login on Armbian"
 description: "Power the board up for the first time, log in as root, set a password, create your everyday user account and connect to a wireless network."
 ---
 # First boot and login

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -1,5 +1,6 @@
 ---
 title: First steps after login
+seo_title: "First steps after installing Armbian"
 description: "Configure a fresh Armbian system with armbian-config: language, keyboard, SSH, upgrades and networking, then install preconfigured software titles."
 ---
 # First steps

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+seo_title: "Armbian getting started: flash, boot & update"
 description: "Step-by-step guide to running Armbian on a single-board computer: choose an image, write it to media, first boot and login, then install and keep it updated."
 ---
 # Armbian Getting Started Guide

--- a/docs/getting-started/install-to-internal-storage.md
+++ b/docs/getting-started/install-to-internal-storage.md
@@ -1,5 +1,6 @@
 ---
 title: Installing to internal storage
+seo_title: "Install Armbian to eMMC, SSD or NVMe"
 description: "Move Armbian off the SD card with armbian-install: boot from eMMC, NAND, SPI or UEFI disk with the system on eMMC, SATA, USB or NVMe."
 ---
 # Installing to internal storage

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: If something goes wrong
+seo_title: "Armbian first-boot troubleshooting"
 description: "What to do when a step in the Armbian Getting Started guide fails, where the troubleshooting and recovery guide lives, and how to report a real bug."
 ---
 # If something goes wrong

--- a/docs/getting-started/writing-the-image.md
+++ b/docs/getting-started/writing-the-image.md
@@ -1,5 +1,6 @@
 ---
 title: Writing the image to media
+seo_title: "Flash Armbian to an SD card or USB"
 description: "Write an Armbian image to an SD card with Armbian Imager, or flash it straight to a board's internal eMMC, UFS or SPI storage over USB."
 ---
 # Writing the image to your media

--- a/docs/releases/release-model.md
+++ b/docs/releases/release-model.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian release model & schedule"
 description: "How Armbian releases: daily and weekly rolling builds, quarterly point releases (Feb/May/Aug/Nov), the release branch and source-freeze process, and version numbering."
 ---
 

--- a/docs/software/actual-budget.md
+++ b/docs/software/actual-budget.md
@@ -1,5 +1,6 @@
 ---
 title: "Actual Budget"
+seo_title: "Install Actual Budget on Armbian"
 description: "Install and run Actual Budget on Armbian — Do your finances with Actual Budget. Runs on ARM64 and x86 single-board computers."
 image: /images/ABU001.png
 category: "Finance"

--- a/docs/software/adguardhome.md
+++ b/docs/software/adguardhome.md
@@ -1,5 +1,6 @@
 ---
 title: "AdGuardHome"
+seo_title: "Install AdGuardHome on Armbian"
 description: "Install and run AdGuardHome on Armbian — AdGuardHome DNS sinkhole. Runs on ARM64 and x86 single-board computers."
 image: /images/ADG001.png
 category: "DNS"

--- a/docs/software/apt-cacher-ng.md
+++ b/docs/software/apt-cacher-ng.md
@@ -1,5 +1,6 @@
 ---
 title: "apt-cacher-ng"
+seo_title: "Install apt-cacher-ng on Armbian"
 description: "Install and run apt-cacher-ng on Armbian — apt-cacher-ng caching proxy install. Runs on ARM64 and x86 single-board computers."
 image: /images/APT001.png
 category: "Management"

--- a/docs/software/avahi-daemon.md
+++ b/docs/software/avahi-daemon.md
@@ -1,5 +1,6 @@
 ---
 title: "avahi-daemon"
+seo_title: "Install avahi-daemon on Armbian"
 description: "Install and run avahi-daemon on Armbian — avahi-daemon hostname broadcast via mDNS. Runs on ARM64 and x86 single-board computers."
 image: /images/AVH001.png
 category: "Netconfig"

--- a/docs/software/bazarr.md
+++ b/docs/software/bazarr.md
@@ -1,5 +1,6 @@
 ---
 title: "Bazarr"
+seo_title: "Install Bazarr on Armbian"
 description: "Install and run Bazarr on Armbian — Bazarr automatic subtitles downloader for Sonarr and Radarr. Runs on ARM64 and x86 single-board computers."
 image: /images/BAZ001.png
 category: "Downloaders"

--- a/docs/software/cdn-router.md
+++ b/docs/software/cdn-router.md
@@ -1,5 +1,6 @@
 ---
 title: "CDN router"
+seo_title: "Install CDN router on Armbian"
 description: "Install and run CDN router on Armbian — Router for repository mirror automation. Runs on ARM64 and x86 single-board computers."
 image: /images/ART001.png
 category: "Armbian"

--- a/docs/software/cockpit.md
+++ b/docs/software/cockpit.md
@@ -1,5 +1,6 @@
 ---
 title: "Cockpit"
+seo_title: "Install Cockpit on Armbian"
 description: "Install and run Cockpit on Armbian — Cockpit OS and VM management tool. Runs on ARM64 and x86 single-board computers."
 image: /images/CPT001.png
 category: "Management"

--- a/docs/software/code-server.md
+++ b/docs/software/code-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Code-server"
+seo_title: "Install Code-server on Armbian"
 description: "Install and run Code-server on Armbian — Code-server VS Code in browser. Runs on ARM64 and x86 single-board computers."
 image: /images/COD001.png
 category: "DevTools"

--- a/docs/software/deluge.md
+++ b/docs/software/deluge.md
@@ -1,5 +1,6 @@
 ---
 title: "Deluge"
+seo_title: "Install Deluge on Armbian"
 description: "Install and run Deluge on Armbian — Deluge BitTorrent client. Runs on ARM64 and x86 single-board computers."
 image: /images/DEL001.png
 category: "Downloaders"

--- a/docs/software/docker.md
+++ b/docs/software/docker.md
@@ -1,5 +1,6 @@
 ---
 title: "Docker"
+seo_title: "Install Docker on Armbian"
 description: "Install and run Docker on Armbian — Docker helps developers build, share, run, and verify applications anywhere - without tedious environment configuration or management. Runs on ARM64 and x86 single-board computers."
 image: /images/CON001.png
 category: "Containers"

--- a/docs/software/domoticz.md
+++ b/docs/software/domoticz.md
@@ -1,5 +1,6 @@
 ---
 title: "Domoticz"
+seo_title: "Install Domoticz on Armbian"
 description: "Install and run Domoticz on Armbian — Domoticz open source home automation. Runs on ARM64 and x86 single-board computers."
 image: /images/DOM001.png
 category: "HomeAutomation"

--- a/docs/software/dozzle.md
+++ b/docs/software/dozzle.md
@@ -1,5 +1,6 @@
 ---
 title: "Dozzle"
+seo_title: "Install Dozzle on Armbian"
 description: "Install and run Dozzle on Armbian — Dozzle real-time Docker log viewer. Runs on ARM64 and x86 single-board computers."
 image: /images/DOZ001.png
 category: "Monitoring"

--- a/docs/software/duplicati.md
+++ b/docs/software/duplicati.md
@@ -1,5 +1,6 @@
 ---
 title: "Duplicati"
+seo_title: "Install Duplicati on Armbian"
 description: "Install and run Duplicati on Armbian — Duplicati install. Runs on ARM64 and x86 single-board computers."
 image: /images/DPL001.png
 category: "Backup"

--- a/docs/software/emby.md
+++ b/docs/software/emby.md
@@ -1,5 +1,6 @@
 ---
 title: "Emby"
+seo_title: "Install Emby on Armbian"
 description: "Install and run Emby on Armbian — Emby organizes video, music, live TV, and photos. Runs on ARM64 and x86 single-board computers."
 image: /images/EMB001.png
 category: "Media"

--- a/docs/software/evcc.md
+++ b/docs/software/evcc.md
@@ -1,5 +1,6 @@
 ---
 title: "EVCC"
+seo_title: "Install EVCC on Armbian"
 description: "Install and run EVCC on Armbian — solar charging automation. Runs on ARM64 and x86 single-board computers."
 image: /images/EVCC01.png
 category: "HomeAutomation"

--- a/docs/software/filebrowser.md
+++ b/docs/software/filebrowser.md
@@ -1,5 +1,6 @@
 ---
 title: "Filebrowser"
+seo_title: "Install Filebrowser on Armbian"
 description: "Install and run Filebrowser on Armbian — Filebrowser provides a web-based file manager accessible via a browser. Runs on ARM64 and x86 single-board computers."
 image: /images/FIL001.png
 category: "Media"

--- a/docs/software/gh-runners.md
+++ b/docs/software/gh-runners.md
@@ -1,5 +1,6 @@
 ---
 title: "GH runners"
+seo_title: "Install GH runners on Armbian"
 description: "Install and run GH runners on Armbian — GitHub runners for Armbian automation. Runs on ARM64 and x86 single-board computers."
 image: /images/GHR001.png
 category: "Armbian"

--- a/docs/software/ghost.md
+++ b/docs/software/ghost.md
@@ -1,5 +1,6 @@
 ---
 title: "Ghost"
+seo_title: "Install Ghost on Armbian"
 description: "Install and run Ghost on Armbian — Ghost CMS install. Runs on ARM64 and x86 single-board computers."
 image: /images/GHOST1.png
 category: "WebHosting"

--- a/docs/software/git-cdn.md
+++ b/docs/software/git-cdn.md
@@ -1,5 +1,6 @@
 ---
 title: "git_cdn"
+seo_title: "Install git_cdn on Armbian"
 description: "Install and run git_cdn on Armbian — git_cdn GitHub caching proxy install. Runs on ARM64 and x86 single-board computers."
 image: /images/GCD001.png
 category: "Management"

--- a/docs/software/git-cli.md
+++ b/docs/software/git-cli.md
@@ -1,5 +1,6 @@
 ---
 title: "Git CLI"
+seo_title: "Install Git CLI on Armbian"
 description: "Install and run Git CLI on Armbian — Install tools for cloning and managing repositories (git). Runs on ARM64 and x86 single-board computers."
 image: /images/GIT001.png
 category: "DevTools"

--- a/docs/software/grafana.md
+++ b/docs/software/grafana.md
@@ -1,5 +1,6 @@
 ---
 title: "Grafana"
+seo_title: "Install Grafana on Armbian"
 description: "Install and run Grafana on Armbian — Grafana data analytics. Runs on ARM64 and x86 single-board computers."
 image: /images/GRA001.png
 category: "Monitoring"

--- a/docs/software/hastebin.md
+++ b/docs/software/hastebin.md
@@ -1,5 +1,6 @@
 ---
 title: "Hastebin"
+seo_title: "Install Hastebin on Armbian"
 description: "Install and run Hastebin on Armbian — Hastebin Paste Server. Runs on ARM64 and x86 single-board computers."
 image: /images/HPS001.png
 category: "Media"

--- a/docs/software/home-assistant.md
+++ b/docs/software/home-assistant.md
@@ -1,5 +1,6 @@
 ---
 title: "Home Assistant"
+seo_title: "Install Home Assistant on Armbian"
 description: "Install and run Home Assistant on Armbian — Home Assistant open source home automation. Runs on ARM64 and x86 single-board computers."
 image: /images/HAS001.png
 category: "HomeAutomation"

--- a/docs/software/homepage.md
+++ b/docs/software/homepage.md
@@ -1,5 +1,6 @@
 ---
 title: "Homepage"
+seo_title: "Install Homepage on Armbian"
 description: "Install and run Homepage on Armbian — Install Homepage startpage / application dashboard. Runs on ARM64 and x86 single-board computers."
 image: /images/HPG001.png
 category: "Management"

--- a/docs/software/immich.md
+++ b/docs/software/immich.md
@@ -1,5 +1,6 @@
 ---
 title: "Immich"
+seo_title: "Install Immich on Armbian"
 description: "Install and run Immich on Armbian — high-performance self-hosted photo and video backup solution. Runs on ARM64 and x86 single-board computers."
 image: /images/IMM001.png
 category: "Media"

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -1,4 +1,5 @@
 ---
+seo_title: "Armbian software: install apps & services on SBCs"
 description: "Install self-hosted apps and services on Armbian single-board computers with armbian-config: Docker and native packages for media servers, dashboards, VPNs and more."
 ---
 

--- a/docs/software/iperf3.md
+++ b/docs/software/iperf3.md
@@ -1,5 +1,6 @@
 ---
 title: "iperf3"
+seo_title: "Install iperf3 on Armbian"
 description: "Install and run iperf3 on Armbian — iperf3 bandwidth measuring tool. Runs on ARM64 and x86 single-board computers."
 image: /images/IPR001.png
 category: "Netconfig"

--- a/docs/software/iptraf-ng.md
+++ b/docs/software/iptraf-ng.md
@@ -1,5 +1,6 @@
 ---
 title: "iptraf-ng"
+seo_title: "Install iptraf-ng on Armbian"
 description: "Install and run iptraf-ng on Armbian — iptraf-ng IP LAN monitor. Runs on ARM64 and x86 single-board computers."
 image: /images/IPT001.png
 category: "Netconfig"

--- a/docs/software/jellyfin.md
+++ b/docs/software/jellyfin.md
@@ -1,5 +1,6 @@
 ---
 title: "Jellyfin"
+seo_title: "Install Jellyfin on Armbian"
 description: "Install and run Jellyfin on Armbian — Jellyfin Media System. Runs on ARM64 and x86 single-board computers."
 image: /images/JMS001.png
 category: "Media"

--- a/docs/software/jellyseerr.md
+++ b/docs/software/jellyseerr.md
@@ -1,5 +1,6 @@
 ---
 title: "Jellyseerr"
+seo_title: "Install Jellyseerr on Armbian"
 description: "Install and run Jellyseerr on Armbian — Jellyseerr Jellyfin/Emby/Plex integration install. Runs on ARM64 and x86 single-board computers."
 image: /images/JEL001.png
 category: "Downloaders"

--- a/docs/software/lidarr.md
+++ b/docs/software/lidarr.md
@@ -1,5 +1,6 @@
 ---
 title: "Lidarr"
+seo_title: "Install Lidarr on Armbian"
 description: "Install and run Lidarr on Armbian — Lidarr automatic music downloader. Runs on ARM64 and x86 single-board computers."
 image: /images/LID001.png
 category: "Downloaders"

--- a/docs/software/mariadb.md
+++ b/docs/software/mariadb.md
@@ -1,5 +1,6 @@
 ---
 title: "Mariadb"
+seo_title: "Install Mariadb on Armbian"
 description: "Install and run Mariadb on Armbian — Mariadb SQL database server. Runs on ARM64 and x86 single-board computers."
 image: /images/DAT001.png
 category: "Database"

--- a/docs/software/medusa.md
+++ b/docs/software/medusa.md
@@ -1,5 +1,6 @@
 ---
 title: "Medusa"
+seo_title: "Install Medusa on Armbian"
 description: "Install and run Medusa on Armbian — Medusa automatic downloader for TV shows. Runs on ARM64 and x86 single-board computers."
 image: /images/MDS001.png
 category: "Downloaders"

--- a/docs/software/mysql.md
+++ b/docs/software/mysql.md
@@ -1,5 +1,6 @@
 ---
 title: "MySQL"
+seo_title: "Install MySQL on Armbian"
 description: "Install and run MySQL on Armbian — MySQL SQL database server. Runs on ARM64 and x86 single-board computers."
 image: /images/MYSQL1.png
 category: "Database"

--- a/docs/software/navidrome.md
+++ b/docs/software/navidrome.md
@@ -1,5 +1,6 @@
 ---
 title: "Navidrome"
+seo_title: "Install Navidrome on Armbian"
 description: "Install and run Navidrome on Armbian — Navidrome music server and streamer compatible with Subsonic/Airsonic. Runs on ARM64 and x86 single-board computers."
 image: /images/NAV001.png
 category: "Media"

--- a/docs/software/netalertx.md
+++ b/docs/software/netalertx.md
@@ -1,5 +1,6 @@
 ---
 title: "NetAlertX"
+seo_title: "Install NetAlertX on Armbian"
 description: "Install and run NetAlertX on Armbian — NetAlertX network scanner & notification framework. Runs on ARM64 and x86 single-board computers."
 image: /images/NAX001.png
 category: "Monitoring"

--- a/docs/software/netbox.md
+++ b/docs/software/netbox.md
@@ -1,5 +1,6 @@
 ---
 title: "NetBox"
+seo_title: "Install NetBox on Armbian"
 description: "Install and run NetBox on Armbian — NetBox infrastructure resource modeling install. Runs on ARM64 and x86 single-board computers."
 image: /images/NBOX01.png
 category: "Management"

--- a/docs/software/netdata.md
+++ b/docs/software/netdata.md
@@ -1,5 +1,6 @@
 ---
 title: "Netdata"
+seo_title: "Install Netdata on Armbian"
 description: "Install and run Netdata on Armbian — monitoring real-time metrics. Runs on ARM64 and x86 single-board computers."
 image: /images/NTD001.png
 category: "Monitoring"

--- a/docs/software/nextcloud.md
+++ b/docs/software/nextcloud.md
@@ -1,5 +1,6 @@
 ---
 title: "Nextcloud"
+seo_title: "Install Nextcloud on Armbian"
 description: "Install and run Nextcloud on Armbian — Nextcloud content collaboration platform. Runs on ARM64 and x86 single-board computers."
 image: /images/NCT001.png
 category: "Media"

--- a/docs/software/nload.md
+++ b/docs/software/nload.md
@@ -1,5 +1,6 @@
 ---
 title: "nload"
+seo_title: "Install nload on Armbian"
 description: "Install and run nload on Armbian — realtime console network usage monitor. Runs on ARM64 and x86 single-board computers."
 image: /images/NLD001.png
 category: "Netconfig"

--- a/docs/software/octoprint.md
+++ b/docs/software/octoprint.md
@@ -1,5 +1,6 @@
 ---
 title: "OctoPrint"
+seo_title: "Install OctoPrint on Armbian"
 description: "Install and run OctoPrint on Armbian — OctoPrint web-based 3D printers management tool. Runs on ARM64 and x86 single-board computers."
 image: /images/OCT001.png
 category: "Printing"

--- a/docs/software/omv.md
+++ b/docs/software/omv.md
@@ -1,5 +1,6 @@
 ---
 title: "OMV"
+seo_title: "Install OMV on Armbian"
 description: "Install and run OMV on Armbian — Deploy NAS using OpenMediaVault. Runs on ARM64 and x86 single-board computers."
 image: /images/OMV001.png
 category: "Media"

--- a/docs/software/openhab.md
+++ b/docs/software/openhab.md
@@ -1,5 +1,6 @@
 ---
 title: "openHAB"
+seo_title: "Install openHAB on Armbian"
 description: "Install and run openHAB on Armbian — openHAB empowering the smart home. Runs on ARM64 and x86 single-board computers."
 image: /images/HAB001.png
 category: "HomeAutomation"

--- a/docs/software/owncloud.md
+++ b/docs/software/owncloud.md
@@ -1,5 +1,6 @@
 ---
 title: "Owncloud"
+seo_title: "Install Owncloud on Armbian"
 description: "Install and run Owncloud on Armbian — Owncloud share files and folders, easy and secure. Runs on ARM64 and x86 single-board computers."
 image: /images/OWC001.png
 category: "Media"

--- a/docs/software/phpmyadmin.md
+++ b/docs/software/phpmyadmin.md
@@ -1,5 +1,6 @@
 ---
 title: "phpMyAdmin"
+seo_title: "Install phpMyAdmin on Armbian"
 description: "Install and run phpMyAdmin on Armbian — phpMyAdmin web interface manager. Runs on ARM64 and x86 single-board computers."
 image: /images/MYA001.png
 category: "Database"

--- a/docs/software/pi-hole.md
+++ b/docs/software/pi-hole.md
@@ -1,5 +1,6 @@
 ---
 title: "Pi-hole"
+seo_title: "Install Pi-hole on Armbian"
 description: "Install and run Pi-hole on Armbian — Pi-hole DNS ad blocker with Unbound support. Runs on ARM64 and x86 single-board computers."
 image: /images/PIH001.png
 category: "DNS"

--- a/docs/software/portainer.md
+++ b/docs/software/portainer.md
@@ -1,5 +1,6 @@
 ---
 title: "Portainer"
+seo_title: "Install Portainer on Armbian"
 description: "Install and run Portainer on Armbian — Portainer container management platform. Runs on ARM64 and x86 single-board computers."
 image: /images/POR001.png
 category: "Containers"

--- a/docs/software/postgresql.md
+++ b/docs/software/postgresql.md
@@ -1,5 +1,6 @@
 ---
 title: "PostgreSQL"
+seo_title: "Install PostgreSQL on Armbian"
 description: "Install and run PostgreSQL on Armbian — PostgreSQL install. Runs on ARM64 and x86 single-board computers."
 image: /images/PGSQL1.png
 category: "Database"

--- a/docs/software/prometheus.md
+++ b/docs/software/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: "Prometheus"
+seo_title: "Install Prometheus on Armbian"
 description: "Install and run Prometheus on Armbian — Prometheus monitoring and alerting toolkit. Runs on ARM64 and x86 single-board computers."
 image: /images/PRO001.png
 category: "Monitoring"

--- a/docs/software/prowlarr.md
+++ b/docs/software/prowlarr.md
@@ -1,5 +1,6 @@
 ---
 title: "Prowlarr"
+seo_title: "Install Prowlarr on Armbian"
 description: "Install and run Prowlarr on Armbian — Prowlarr index manager and proxy for PVR. Runs on ARM64 and x86 single-board computers."
 image: /images/PRW001.png
 category: "Downloaders"

--- a/docs/software/proxmox-ve.md
+++ b/docs/software/proxmox-ve.md
@@ -1,5 +1,6 @@
 ---
 title: "Proxmox VE"
+seo_title: "Install Proxmox VE on Armbian"
 description: "Install and run Proxmox VE on Armbian — Proxmox VE virtualization platform (keeps the Armbian kernel). Runs on ARM64 and x86 single-board computers."
 image: /images/PVE001.png
 category: "Management"

--- a/docs/software/qbittorrent.md
+++ b/docs/software/qbittorrent.md
@@ -1,5 +1,6 @@
 ---
 title: "qBittorrent"
+seo_title: "Install qBittorrent on Armbian"
 description: "Install and run qBittorrent on Armbian — qBittorrent BitTorrent client. Runs on ARM64 and x86 single-board computers."
 image: /images/QBT001.png
 category: "Downloaders"

--- a/docs/software/radarr.md
+++ b/docs/software/radarr.md
@@ -1,5 +1,6 @@
 ---
 title: "Radarr"
+seo_title: "Install Radarr on Armbian"
 description: "Install and run Radarr on Armbian — Radarr automatic downloader for movies. Runs on ARM64 and x86 single-board computers."
 image: /images/RAD001.png
 category: "Downloaders"

--- a/docs/software/redis.md
+++ b/docs/software/redis.md
@@ -1,5 +1,6 @@
 ---
 title: "Redis"
+seo_title: "Install Redis on Armbian"
 description: "Install and run Redis on Armbian — Redis install. Runs on ARM64 and x86 single-board computers."
 image: /images/REDIS1.png
 category: "Database"

--- a/docs/software/rsyncd-server.md
+++ b/docs/software/rsyncd-server.md
@@ -1,5 +1,6 @@
 ---
 title: "Rsyncd server"
+seo_title: "Install Rsyncd server on Armbian"
 description: "Install and run Rsyncd server on Armbian — Rsyncd server. Runs on ARM64 and x86 single-board computers."
 image: /images/RSD001.png
 category: "Armbian"

--- a/docs/software/sabnzbd.md
+++ b/docs/software/sabnzbd.md
@@ -1,5 +1,6 @@
 ---
 title: "SABnzbd"
+seo_title: "Install SABnzbd on Armbian"
 description: "Install and run SABnzbd on Armbian — SABnzbd newsgroup downloader. Runs on ARM64 and x86 single-board computers."
 image: /images/SABN01.png
 category: "Downloaders"

--- a/docs/software/samba.md
+++ b/docs/software/samba.md
@@ -1,5 +1,6 @@
 ---
 title: "Samba"
+seo_title: "Install Samba on Armbian"
 description: "Install and run Samba on Armbian — SAMBA Remote File share. Runs on ARM64 and x86 single-board computers."
 image: /images/SMB001.png
 category: "Management"

--- a/docs/software/sonarr.md
+++ b/docs/software/sonarr.md
@@ -1,5 +1,6 @@
 ---
 title: "Sonarr"
+seo_title: "Install Sonarr on Armbian"
 description: "Install and run Sonarr on Armbian — Sonarr automatic downloader for TV shows. Runs on ARM64 and x86 single-board computers."
 image: /images/SON001.png
 category: "Downloaders"

--- a/docs/software/stirling.md
+++ b/docs/software/stirling.md
@@ -1,5 +1,6 @@
 ---
 title: "Stirling"
+seo_title: "Install Stirling on Armbian"
 description: "Install and run Stirling on Armbian — Stirling PDF tools for viewing and editing PDF files. Runs on ARM64 and x86 single-board computers."
 image: /images/STR001.png
 category: "Media"

--- a/docs/software/swag.md
+++ b/docs/software/swag.md
@@ -1,5 +1,6 @@
 ---
 title: "SWAG"
+seo_title: "Install SWAG on Armbian"
 description: "Install and run SWAG on Armbian — SWAG reverse proxy. Runs on ARM64 and x86 single-board computers."
 image: /images/SWAG01.png
 category: "WebHosting"

--- a/docs/software/syncthing.md
+++ b/docs/software/syncthing.md
@@ -1,5 +1,6 @@
 ---
 title: "Syncthing"
+seo_title: "Install Syncthing on Armbian"
 description: "Install and run Syncthing on Armbian — Syncthing continuous file synchronization. Runs on ARM64 and x86 single-board computers."
 image: /images/STC001.png
 category: "Media"

--- a/docs/software/transmission.md
+++ b/docs/software/transmission.md
@@ -1,5 +1,6 @@
 ---
 title: "Transmission"
+seo_title: "Install Transmission on Armbian"
 description: "Install and run Transmission on Armbian — Transmission BitTorrent client. Runs on ARM64 and x86 single-board computers."
 image: /images/TRA001.png
 category: "Downloaders"

--- a/docs/software/unbound.md
+++ b/docs/software/unbound.md
@@ -1,5 +1,6 @@
 ---
 title: "Unbound"
+seo_title: "Install Unbound on Armbian"
 description: "Install and run Unbound on Armbian — Unbound caching DNS resolver. Runs on ARM64 and x86 single-board computers."
 image: /images/UNB001.png
 category: "DNS"

--- a/docs/software/uptime-kuma.md
+++ b/docs/software/uptime-kuma.md
@@ -1,5 +1,6 @@
 ---
 title: "Uptime Kuma"
+seo_title: "Install Uptime Kuma on Armbian"
 description: "Install and run Uptime Kuma on Armbian — Uptime Kuma self-hosted monitoring tool. Runs on ARM64 and x86 single-board computers."
 image: /images/UPK001.png
 category: "Monitoring"

--- a/docs/software/wallos.md
+++ b/docs/software/wallos.md
@@ -1,5 +1,6 @@
 ---
 title: "Wallos"
+seo_title: "Install Wallos on Armbian"
 description: "Install and run Wallos on Armbian — Install Wallos subscription tracker. Runs on ARM64 and x86 single-board computers."
 image: /images/WAL001.png
 category: "Finance"

--- a/docs/software/webmin.md
+++ b/docs/software/webmin.md
@@ -1,5 +1,6 @@
 ---
 title: "Webmin"
+seo_title: "Install Webmin on Armbian"
 description: "Install and run Webmin on Armbian — Webmin web-based management tool. Runs on ARM64 and x86 single-board computers."
 image: /images/WBM001.png
 category: "Management"

--- a/docs/software/wireguard.md
+++ b/docs/software/wireguard.md
@@ -1,5 +1,6 @@
 ---
 title: "WireGuard"
+seo_title: "Install WireGuard on Armbian"
 description: "Install and run WireGuard on Armbian — WireGuard VPN server. Runs on ARM64 and x86 single-board computers."
 image: /images/WRG001.png
 category: "VPN"

--- a/docs/software/zerotier.md
+++ b/docs/software/zerotier.md
@@ -1,5 +1,6 @@
 ---
 title: "ZeroTier"
+seo_title: "Install ZeroTier on Armbian"
 description: "Install and run ZeroTier on Armbian — ZeroTier connect devices over your own private network in the world. Runs on ARM64 and x86 single-board computers."
 image: /images/ZTR001.png
 category: "VPN"

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -4,13 +4,25 @@
      Material already emits <meta name="description"> from page.meta.description;
      this adds the social equivalents plus og:image (the app logo shipped as
      `image:` in front-matter). Falls back to the site defaults elsewhere. -->
+{# Keyword-rich browser <title> from a dedicated `seo_title:` front-matter
+   field. Unlike Material's `title:`, this does NOT change the (short) left-nav
+   label — it only rewrites the <title> tag, so nav stays clean while the title
+   leads with search keywords. #}
+{% block htmltitle %}
+  {% if page and page.meta and page.meta.seo_title %}
+    <title>{{ page.meta.seo_title }}</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
-  {# page.title is the nav label, which the theme's <title> overrides with
-     page.meta.title when a page sets one. Follow the same order here so the
-     social cards do not disagree with the browser title. #}
+  {# Prefer seo_title so the social cards match the browser <title>; else fall
+     back to page.meta.title / nav title + site name (Material's own order). #}
+  {% set _seo_title = (page.meta.seo_title if page and page.meta and page.meta.seo_title else None) %}
   {% set _page_title = (page.meta.title if page and page.meta and page.meta.title else (page.title if page else None)) %}
-  {% set _title = (_page_title ~ " - " ~ config.site_name) if _page_title else config.site_name %}
+  {% set _title = _seo_title if _seo_title else ((_page_title ~ " - " ~ config.site_name) if _page_title else config.site_name) %}
   {% set _desc = (page.meta.description if page and page.meta and page.meta.description else config.site_description) %}
   <meta property="og:type" content="website">
   <meta property="og:title" content="{{ _title }}">


### PR DESCRIPTION
## What

Follow-up to the meta-description PR. Many pages rendered a bare, keyword-thin browser `<title>` derived from their H1 — `Overview`, `Automation`, `Jira`, `Forums`, `Networking` — and one was outright wrong: the build-host prep page rendered as **"Getting Started"**. The `<title>` is the strongest on-page ranking signal and the clickable headline in search results.

## How

A dedicated `seo_title:` front-matter field + a `htmltitle` override in `overrides/main.html` that rewrites **only** the `<title>` tag. Material's `title:` (the short left-nav label) is left untouched — so nav stays clean while titles lead with keywords. `og:title`/`twitter:title` follow `seo_title` so social cards match.

## Changes

- **~40 hand-written pages** + the 3 section overviews + the getting-started flow get curated titles, e.g.
  - `Developer-Guide_Build-Preparation` → **Armbian build host setup & requirements** (was the misleading "Getting Started")
  - `Process_CI` → **Armbian release automation & CI pipeline** (was "Automation")
  - `User-Guide_Networking` → **Armbian networking: static IP, Wi-Fi & Netplan**
- **92 generated config/software pages** carry the `seo_title` now emitted by [configng#999](https://github.com/armbian/configng/pull/999) — `Install Netdata on Armbian`, `Armbian kernels, headers & device-tree overlays`, `VPN apps for Armbian` — synced here so the fix is live on merge (every one a +1-line change).

## Result

`mkdocs build --strict`: every non-redirect content page has a **unique** `<title>` that leads with a keyword; none exceed ~55 characters. `&` renders correctly (autoescaped).

> Pairs with configng#999. Merge either order; this PR bundles the current generated output and the generator keeps it correct on the next auto-pull.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1005"><kbd><br> Open WWW preview <br></kbd></a>