### PR TITLE
docs: recommend armbian-upgrade for updating the OS

### DIFF
--- a/docs/getting-started/updating.md
+++ b/docs/getting-started/updating.md
@@ -1,6 +1,6 @@
 ---
 title: Keeping Armbian up to date
-description: "Update an Armbian system: APT for the base operating system, armbian-install for the boot loader, and how the firmware package freeze protects you."
+description: "Update an Armbian system: armbian-upgrade for the base operating system, armbian-install for the boot loader, and how the firmware package freeze protects you."
 ---
 # Keeping the system up to date
 
@@ -9,10 +9,11 @@ The operating system consists of two parts that must be updated separately.
 
 ## Update the Armbian OS
 
-For the base operating system, use the APT package manager to keep the packages up to date.
+For the base operating system, run:
 
-    apt update
-    apt upgrade
+    armbian-upgrade
+
+`armbian-upgrade` is Armbian's wrapper around APT: it refreshes the package lists, upgrades all installed packages, then cleans the package cache and removes anything no longer needed (`apt-get update && apt-get upgrade`, followed by `apt-get clean` and `apt-get autoremove`). It elevates itself with `sudo` automatically, so you can run it as a normal user.
 
 **The Update process can take quite some time in case you are using an old or a cheap SD card and/or experience heavy load.**
 


### PR DESCRIPTION
On the [Keeping Armbian up to date](https://docs.armbian.com/getting-started/updating/) page, the **Update the Armbian OS** section told users to run `apt update` / `apt upgrade` directly. Switched it to recommend the **`armbian-upgrade`** command instead.

`armbian-upgrade` is the BSP wrapper (`/usr/bin/armbian-upgrade`) — it self-elevates with `sudo` and runs:

```
apt-get update
apt-get -y upgrade
apt-get clean
apt-get -y autoremove
```

so it also cleans the cache and prunes leftovers, uses `apt-get` (no "unstable CLI" warning), and honours the Armbian firmware freeze. It's the same command surfaced in the login MOTD's "Upgrade" hint, and is already described in the FAQ.

Only the one section changed; the boot-loader / `armbian-install` section and the firmware-freeze note are untouched.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1008"><kbd><br> Open WWW preview <br></kbd></a>