### PR TITLE
ci(docs-preview): delete PR preview from www on close + one-time prune

### DIFF
--- a/.github/workflows/pdf-at-pr.yaml
+++ b/.github/workflows/pdf-at-pr.yaml
@@ -2,7 +2,7 @@ name: Create docs preview on PR
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize, labeled, closed]
   workflow_dispatch:
 
 permissions:
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   docs-preview:
+    # Build/publish a preview only while the PR is active; on close we clean up instead.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,3 +80,41 @@ jobs:
 
             <a href="https://armbian.github.io/documentation/${{ github.event.number }}"><kbd><br> Open WWW preview <br></kbd></a>
           body-update-action: suffix
+
+  # When a PR is closed (merged or not), delete its preview build from the `www`
+  # branch so previews stop accumulating there. Without this, every PR left a
+  # full site copy under www/<PR#>/ forever, which grew the GitHub Pages source
+  # past its 1 GB limit and broke deployment.
+  cleanup-preview:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout `www` branch
+        uses: actions/checkout@v7
+        with:
+          ref: www
+
+      - name: Remove preview for closed PR
+        env:
+          PR: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          if [ ! -d "${PR}" ]; then
+            echo "No preview directory for PR #${PR}; nothing to do."
+            exit 0
+          fi
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rm -r --quiet "${PR}"
+          git commit -m "www: remove docs preview for closed PR #${PR}"
+          # Retry against concurrent preview pushes from other PRs.
+          for attempt in 1 2 3; do
+            if git push origin www; then
+              echo "Removed preview for PR #${PR}."
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}); rebasing on latest www..." >&2
+            git pull --rebase origin www
+          done
+          echo "Failed to push preview removal for PR #${PR} after 3 attempts." >&2
+          exit 1


### PR DESCRIPTION
## Problem

The GitHub Pages deploy was failing:

> `Uploaded artifact size of 2103402113 bytes exceeds the allowed size of 1 GB. Deployment might fail.` → `Timeout reached, aborting!`

Pages serves from the **`www` branch** (`build_type: legacy`, `source.branch = www`). The [`pdf-at-pr.yaml`](.github/workflows/pdf-at-pr.yaml) workflow rsyncs a full ~30 MB mkdocs site build into `www/<PR#>/` for **every PR** and **never removed them**. **227 previews (#490–#1009) accumulated to ~3.5 GB**, exceeding the Pages 1 GB limit → deploy hung in `syncing_files` and timed out. (The repo's actual source images are only ~11 MB — a red herring.)

## Fix

**1. Workflow (this PR):** add a `cleanup-preview` job triggered on `pull_request: closed` that deletes `www/<PR#>/` (commit + push, with rebase-retry against concurrent preview pushes). The existing build/publish job is gated with `if: github.event.action != 'closed'`, so closing a PR now *cleans up* instead of rebuilding. Fork PRs never publish a preview, so cleanup keeps the same base-repo guard and is a no-op for them.

**2. One-time prune (already applied to `www`):** pruned the 227 accumulated previews down to the **5 currently-open-PR previews** (854, 942, 971, 1008, 1009). Done as a normal commit on `www` (parent `978e629`), so it's reversible. Deployed tree is now ~150 MB, comfortably under 1 GB — the next Pages deploy should succeed.

## Notes

- `www` **history** still contains the old blobs, so a clone stays large; the *deployed tree* (what Pages uploads) is what matters and is now small. If you also want to shrink the branch itself, I can orphan-squash `www` in a follow-up.
- Source-image shrink/orphan-removal was intentionally left out of scope for now.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1010"><kbd><br> Open WWW preview <br></kbd></a>