### PR TITLE
docs(build): modernize Getting Started (desktop example + SHARE_LOG)

### DIFF
--- a/docs/build-framework/getting-started.md
+++ b/docs/build-framework/getting-started.md
@@ -136,6 +136,12 @@ Log formats are:
 
 For much more verbose logs set switch 'DEBUG=yes'.
 
+To share a build log when asking for help, set `SHARE_LOG=yes`. The build uploads the log to Armbian's paste service (`paste.armbian.com`) and prints a URL you can post in the forum or a bug report:
+
+```bash
+./compile.sh build BOARD=uefi-x86 BRANCH=current SHARE_LOG=yes
+```
+
 ## GitHub Actions
 
 If you do not have the proper equipment to build images on your own, you can use our [GitHub Action](https://github.com/marketplace/actions/rebuild-armbian).

--- a/docs/build-framework/getting-started.md
+++ b/docs/build-framework/getting-started.md
@@ -190,6 +190,10 @@ The action will build the image, create a GitHub Release in your repository and 
 | `armbian_release_title` | no | `Armbian image` | GitHub Release title |
 | `armbian_release_body` | no | *(link to build tools)* | GitHub Release body text |
 | `armbian_release_tag` | no | *auto* | GitHub Release tag; defaults to the computed version |
+| `armbian_release_prerelease` | no | `false` | Publish the release as a pre-release (useful for matrix builds; promote later) |
+| `armbian_download_base_url` | no | `https://dl.armbian.com` | Base URL where published images live (used to build the assets manifest URLs) |
+| `armbian_download_repository` | no | `archive` | Repository segment under `<base>/<board>/<repo>/`; empty string gives a flat URL shape |
+| `armbian_index_url` | no | `https://github.armbian.com/armbian-images.json` | Canonical `armbian-images.json` used to enrich entries; empty string skips enrichment |
 | `armbian_artifacts` | no | `build/output/images/` | Path to artifacts for upload |
 | `armbian_runner_clean` | no | — | Set to any non-empty value to free disk space on GitHub-hosted runners |
 

--- a/docs/build-framework/getting-started.md
+++ b/docs/build-framework/getting-started.md
@@ -102,11 +102,10 @@ BOARD=uefi-x86 \
 BRANCH=current \
 BUILD_DESKTOP=yes \
 BUILD_MINIMAL=no \
-DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools' \
 DESKTOP_ENVIRONMENT=gnome \
-DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base \
+DESKTOP_TIER=full \
 KERNEL_CONFIGURE=no \
-RELEASE=noble
+RELEASE=resolute
 ```
 
 Or, using config file `userpatches/config-myboard.conf`
@@ -119,7 +118,7 @@ myboard
 
 !!! question "Interpretation?"
 
-    This command will generate **Ubuntu 24.04 Noble** based **Gnome desktop** environment image for Intel based hardware (**uefi-x86**). Besides bare desktop, it will contain packages from **browsers** and **desktop_tool** sections and it will use unchanged kernel from **current kernel** branch.
+    This command will generate an **Ubuntu 26.04 Resolute** based **GNOME desktop** image for Intel based hardware (**uefi-x86**), using the **full** desktop tier (the bare desktop plus its bundled application set) and an unchanged kernel from the **current** branch.
 
 
 ## Logging


### PR DESCRIPTION
Two fixes to [Getting Started](https://docs.armbian.com/build-framework/getting-started/):

**1. Outdated desktop switches in the build example.** It used removed variables:
- `DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools'` — removed (desktop selection moved to armbian-config YAML tiers), and `desktop_tools` was never a valid appgroup (valid: `apt browsers chat email programming sources`).
- `DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base` — removed.

Both are marked removed in [`config-desktop.sh`](https://github.com/armbian/build/blob/main/lib/functions/configuration/config-desktop.sh) ("Legacy variables (removed — armbian-config YAML tiers subsume them)"). Replaced with **`DESKTOP_TIER=full`** and refreshed the example to **`RELEASE=resolute`** (Ubuntu 26.04), updating the interpretation note to match.

**2. Logging section** now mentions **`SHARE_LOG=yes`**, which uploads the build log to Armbian's paste service (`paste.armbian.com`) and prints a shareable URL — the standard way to attach a log to a forum post or bug report.

Historical `DESKTOP_APPGROUPS_SELECTED` mentions in `releases/*.md` changelogs are left untouched.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1012"><kbd><br> Open WWW preview <br></kbd></a>