### PR TITLE
docs(build): fix outdated facts in build-framework reference pages

### DIFF
--- a/docs/build-framework/commands.md
+++ b/docs/build-framework/commands.md
@@ -16,12 +16,34 @@ Usage:
 
 ### flash
 
-Writes an already-built image to a block device (SD card, USB, eMMC), with an interactive picker for the image and the target device.
+Writes an already-built image to a block device (SD card, USB, eMMC). There is
+no interactive picker: the target device is required, and the image is chosen
+for you.
 
 Usage:
 ```bash
-./compile.sh flash
+./compile.sh flash CARD_DEVICE=/dev/sdX
 ```
+
+`CARD_DEVICE` is mandatory &mdash; run `lsblk` to find the device name. Docker is
+not an obstacle: the launcher passes the device into the container when it is
+set (`DOCKER_SKIP_CARD_DEVICE=yes` opts out).
+
+!!! danger "Check the device name first"
+
+    Everything on `CARD_DEVICE` is overwritten. Naming the wrong disk destroys
+    it, and the command does not ask for confirmation beyond a short countdown.
+
+By default the newest `.img` in `output/images` is flashed. Pass `BOARD`,
+`RELEASE` or `BRANCH` to narrow that down, or `IMAGE` to name a file outright:
+
+```bash
+./compile.sh flash CARD_DEVICE=/dev/sdX BOARD=rockpi-4a BRANCH=current
+./compile.sh flash CARD_DEVICE=/dev/sdX IMAGE=output/images/Armbian_26.8.3_Rockpi-4a_trixie_current_6.12.13.img
+```
+
+The image is read back and verified against its checksum after writing. Set
+`SKIP_VERIFY=yes` to skip that.
 
 ### docker / docker-shell / docker-purge
 

--- a/docs/build-framework/commands.md
+++ b/docs/build-framework/commands.md
@@ -32,7 +32,7 @@ set (`DOCKER_SKIP_CARD_DEVICE=yes` opts out).
 !!! danger "Check the device name first"
 
     Everything on `CARD_DEVICE` is overwritten. Naming the wrong disk destroys
-    it, and the command does not ask for confirmation beyond a short countdown.
+    it.
 
 Pass `BOARD`, `RELEASE` or `BRANCH` to narrow which image is picked, or `IMAGE`
 to name a file outright:
@@ -42,19 +42,13 @@ to name a file outright:
 ./compile.sh flash CARD_DEVICE=/dev/sdX IMAGE=output/images/Armbian_26.8.3_Rockpi-4a_trixie_current_6.12.13.img
 ```
 
-When the image is picked for you, the choice is announced before the countdown,
-so you can check it is the one you meant before anything is written:
+When the image is picked for you, the choice is reported before anything is
+written, so you can check it is the one you meant:
 
 ```text
 [🌱] cli_flash [ No image file specified. Using latest built image file found: Armbian-unofficial_26.08.0-trunk_Bananapim2_resolute_current_6.18.46_minimal.img ]
 [🌱] cli_flash [ Flashing image file: Armbian-unofficial_26.08.0-trunk_Bananapim2_resolute_current_6.18.46_minimal.img ]
-Counting down: 2... 1... 0...
 ```
-
-If that is not the image you wanted, press ++ctrl+c++ during the countdown and
-rerun with `BOARD`, `RELEASE`, `BRANCH` or `IMAGE` to pin it down. Pressing any
-other key makes the countdown finish *sooner*, it does not cancel it, and a run
-with no terminal attached (CI, or piped input) skips the countdown altogether.
 
 The image is read back and verified against its checksum after writing. Set
 `SKIP_VERIFY=yes` to skip that.

--- a/docs/build-framework/commands.md
+++ b/docs/build-framework/commands.md
@@ -5,6 +5,33 @@ description: "Armbian build framework commands for compile.sh: build the kernel,
 
 # Build commands
 
+### build
+
+The default command. Builds a full OS image (or only the requested artifacts, depending on the switches) for the selected board and release. This is what runs when you invoke `./compile.sh` with no command, or explicitly:
+
+Usage:
+```bash
+./compile.sh build BOARD=uefi-x86 BRANCH=current RELEASE=trixie
+```
+
+### flash
+
+Writes an already-built image to a block device (SD card, USB, eMMC), with an interactive picker for the image and the target device.
+
+Usage:
+```bash
+./compile.sh flash
+```
+
+### docker / docker-shell / docker-purge
+
+`docker` runs the build inside Armbian's build container — the default path, since `./compile.sh` relaunches itself in Docker when it is available. `docker-shell` drops you into an interactive shell inside that container (useful for editing sources, inspecting build errors, or running individual build steps), and `docker-purge` removes the container together with its named volumes and cached build image.
+
+Usage:
+```bash
+./compile.sh docker-shell BOARD=rockpi-4a BRANCH=edge RELEASE=trixie
+```
+
 ### kernel
 
 Builds kernel and device tree (where applicable) and places it to the `output/debs`
@@ -46,13 +73,13 @@ Usage:
 
 Outputs a one-board-per-line CSV inventory of boards.
 
-Sets `TARGETS_FILE` to something that doesn't exist, so the `default-targets.yaml` is used (so same list for everyone, save for userpatched-boards)
+Sets `TARGETS_FILE` to something that doesn't exist, so the `targets-default.yaml` is used (so same list for everyone, save for userpatched-boards)
 
 Usage:
 ```bash
 ./compile.sh inventory-boards
 ```
-Outputs /info/boards-inventory.csv
+Outputs output/info/boards-inventory.csv
 
 ### kernel-dtb
 

--- a/docs/build-framework/commands.md
+++ b/docs/build-framework/commands.md
@@ -16,9 +16,9 @@ Usage:
 
 ### flash
 
-Writes an already-built image to a block device (SD card, USB, eMMC). There is
-no interactive picker: the target device is required, and the image is chosen
-for you.
+Writes an already-built image to a block device (SD card, USB, eMMC). Name the
+target device; the newest image in `output/images` is used unless you name one
+too.
 
 Usage:
 ```bash
@@ -34,8 +34,8 @@ set (`DOCKER_SKIP_CARD_DEVICE=yes` opts out).
     Everything on `CARD_DEVICE` is overwritten. Naming the wrong disk destroys
     it, and the command does not ask for confirmation beyond a short countdown.
 
-By default the newest `.img` in `output/images` is flashed. Pass `BOARD`,
-`RELEASE` or `BRANCH` to narrow that down, or `IMAGE` to name a file outright:
+Pass `BOARD`, `RELEASE` or `BRANCH` to narrow which image is picked, or `IMAGE`
+to name a file outright:
 
 ```bash
 ./compile.sh flash CARD_DEVICE=/dev/sdX BOARD=rockpi-4a BRANCH=current

--- a/docs/build-framework/commands.md
+++ b/docs/build-framework/commands.md
@@ -42,6 +42,20 @@ By default the newest `.img` in `output/images` is flashed. Pass `BOARD`,
 ./compile.sh flash CARD_DEVICE=/dev/sdX IMAGE=output/images/Armbian_26.8.3_Rockpi-4a_trixie_current_6.12.13.img
 ```
 
+When the image is picked for you, the choice is announced before the countdown,
+so you can check it is the one you meant before anything is written:
+
+```text
+[🌱] cli_flash [ No image file specified. Using latest built image file found: Armbian-unofficial_26.08.0-trunk_Bananapim2_resolute_current_6.18.46_minimal.img ]
+[🌱] cli_flash [ Flashing image file: Armbian-unofficial_26.08.0-trunk_Bananapim2_resolute_current_6.18.46_minimal.img ]
+Counting down: 2... 1... 0...
+```
+
+If that is not the image you wanted, press ++ctrl+c++ during the countdown and
+rerun with `BOARD`, `RELEASE`, `BRANCH` or `IMAGE` to pin it down. Pressing any
+other key makes the countdown finish *sooner*, it does not cancel it, and a run
+with no terminal attached (CI, or piped input) skips the countdown altogether.
+
 The image is read back and verified against its checksum after writing. Set
 `SKIP_VERIFY=yes` to skip that.
 

--- a/docs/build-framework/index.md
+++ b/docs/build-framework/index.md
@@ -93,7 +93,7 @@ Function | Armbian | Yocto | Buildroot |
 │   │   └── rootfs
 │   └── tools
 ├── output                               Build artifact
-│   └── deb                              Deb packages
+│   └── debs                             Deb packages
 │   └── images                           Bootable images - RAW or compressed
 │   └── debug                            Patch and build logs
 │   └── config                           Kernel configuration export location

--- a/docs/build-framework/switches.md
+++ b/docs/build-framework/switches.md
@@ -54,6 +54,23 @@ releases marked `eos` there are end of service and are not listed here.
 - `yes`: build a bare CLI image suitable for application deployment. This option is **not compatible** with `BUILD_DESKTOP="yes"`
 - `no`: (default)
 
+**BUILD_DESKTOP** ( `string` )
+
+- `yes`: build a desktop image (pick the environment and tier below)
+- `no`: (default)
+
+**DESKTOP_ENVIRONMENT** ( `string` )
+
+Desktop environment to install when `BUILD_DESKTOP=yes` — e.g. `xfce`, `gnome`, `kde-plasma`, `mate`, `cinnamon`. Set manually to skip the dialog prompt; the available environments are provided by armbian-config.
+
+**DESKTOP_TIER** ( `string` )
+
+- `minimal`: bare desktop
+- `mid`: desktop plus a common application set (interactive default)
+- `full`: desktop plus the full bundled application set
+
+Selects how many applications are bundled with the desktop. Replaces the removed `DESKTOP_APPGROUPS_SELECTED` and `DESKTOP_ENVIRONMENT_CONFIG_NAME` switches.
+
 **BSPFREEZE** ( `string` )
 
 - `yes`: freeze (from upgrade) armbian firmware packages when building images (U-Boot, kernel, DTB, BSP)
@@ -74,7 +91,7 @@ releases marked `eos` there are end of service and are not listed here.
 - `systemd-networkd`
 - `none` (to not-add any networking extensions)
 
-Installs desired networking stack. If the parameter is undefined, it sets `systemd-networkd` for minimal images (MINIMAL=yes) and `network-manager` for the rest. Time synchronization is also changed; chrony is installed with network-manager, while systemd-timesyncd is used with systemd-networkd. In both cases, we control network settings using **Netplan**.
+Installs desired networking stack. If the parameter is undefined, it sets `systemd-networkd` for minimal images (BUILD_MINIMAL=yes) and `network-manager` for the rest. Time synchronization is also changed; chrony is installed with network-manager, while systemd-timesyncd is used with systemd-networkd. In both cases, we control network settings using **Netplan**.
 
 !!! example "Build switch example"
 
@@ -198,7 +215,7 @@ Select the target for pull/push OCI cached images. If not set, default is used.
 
 **GHCR_MIRROR_ADDRESS** ( `string` )
 
-The default mirror address for ghcr.io, set by `GHCR_MIRROR=dockerproxy`, is ghcr.dockerproxy.com. When this address is unavailable, an alternative address can be set with `GHCR_MIRROR_ADDRESS`.
+The default mirror address for ghcr.io, set by `GHCR_MIRROR=dockerproxy`, is ghcr.dockerproxy.net. When this address is unavailable, an alternative address can be set with `GHCR_MIRROR_ADDRESS`.
 
 Example:
 

--- a/docs/build-framework/user-configurations.md
+++ b/docs/build-framework/user-configurations.md
@@ -40,12 +40,11 @@ If the file `userpatches/linux-$LINUXFAMILY-$BRANCH.config` exists, it will be u
 
 ## User provided sources config overrides
 
-If file `userpatches/sources/$LINUXFAMILY.conf` exists, it will be used in addition to the default one from `config/sources`. Look for the hint at the beginning of the compilation process to select the proper config file name.
-Please note that there are some exceptions for LINUXFAMILY like `sunxi` (32-bit mainline sunxi) and `sunxi64` (64-bit mainline sunxi)
+If file `userpatches/config/sources/families/$LINUXFAMILY.conf` exists, it is sourced in addition to the default one from `config/sources/families`. Look for the hint at the beginning of the compilation process to confirm the file name being used.
 
 Example:
 	
-	[ o.k. ] Adding user provided sunxi64 overrides
+	[ o.k. ] Sourcing family configuration userpatches/config/sources/families/sunxi64.conf
 	
 ## User provided image customization script
 


### PR DESCRIPTION
Part of a Build Framework docs audit against the current [armbian/build](https://github.com/armbian/build) source. Every change below was verified against the code.

### user-configurations.md (high)
- Family-override path was wrong: `userpatches/sources/$LINUXFAMILY.conf` → **`userpatches/config/sources/families/$LINUXFAMILY.conf`**, and the emitted hint is `Sourcing family configuration <path>` (not "Adding user provided … overrides"). Evidence: `lib/functions/configuration/main-config.sh:578-584`. Dropped the stale sunxi/sunxi64 exception note — `LINUXFAMILY` is used directly.

### commands.md
- Documented the primary user-facing commands that were **missing entirely**: `build` (the default command), `flash`, and `docker` / `docker-shell` / `docker-purge` — all in the command registry (`lib/functions/cli/commands.sh`).
- Fallback template name `default-targets.yaml` → **`targets-default.yaml`** (`config/templates/`).
- Inventory output path `/info/boards-inventory.csv` → **`output/info/boards-inventory.csv`** (`cli-jsoninfo.sh`).

### switches.md
- ghcr mirror default `ghcr.dockerproxy.com` → **`.net`** (`main-config.sh:288`).
- `NETWORKING_STACK` minimal gate: `MINIMAL=yes` → **`BUILD_MINIMAL=yes`** (`main-config.sh:83`).
- Documented the current desktop-selection switches **`DESKTOP_ENVIRONMENT`** and **`DESKTOP_TIER`** (`minimal`/`mid`/`full`) — these replaced the removed `DESKTOP_APPGROUPS_SELECTED` / `DESKTOP_ENVIRONMENT_CONFIG_NAME`.

### index.md
- Output tree listed `deb`; the directory is **`debs`** (`DEB_STORAGE=$DEST/debs`).

`cli.md` was audited and found accurate (no changes).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1013"><kbd><br> Open WWW preview <br></kbd></a>