### PR TITLE
ci: add "Pull extensions list" workflow

### DIFF
--- a/.github/workflows/pull-extensions-list.yml
+++ b/.github/workflows/pull-extensions-list.yml
@@ -14,6 +14,10 @@ on:
   repository_dispatch:
     types: [extensions-changed]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
 
   Build:
@@ -26,13 +30,20 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: 'armbian/documentation'
+          # workflow_dispatch checks out whatever branch the run was started
+          # from; always regenerate against the default branch instead.
+          ref: ${{ github.event.repository.default_branch }}
           path: 'documentation'
+          persist-credentials: false
 
       - name: Checkout build repository
         uses: actions/checkout@v7
         with:
           repository: 'armbian/build'
           path: 'build'
+          # the generator below runs code from this checkout; don't leave the
+          # workflow token sitting in its git config where that code can read it
+          persist-credentials: false
 
       - name: Generate extensions list
         run: |
@@ -44,6 +55,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: documentation
+          base: ${{ github.event.repository.default_branch }}
           commit-message: '`Automatic` extensions list update'
           signoff: false
           branch: auto-update-extensions-list

--- a/.github/workflows/pull-extensions-list.yml
+++ b/.github/workflows/pull-extensions-list.yml
@@ -1,0 +1,57 @@
+name: "Pull extensions list"
+
+# Regenerates docs/build-framework/extensions/list.md from the `# @description`
+# headers in armbian/build's extensions/ directory, and opens a PR. The list is
+# no longer hand-maintained: edit an extension's `# @description` in armbian/build
+# and this workflow brings the change over.
+
+on:
+  workflow_dispatch:
+  # Trigger from armbian/build via repository_dispatch after an extensions change:
+  #   curl -X POST -H "Authorization: token <PAT>" \
+  #     https://api.github.com/repos/armbian/documentation/dispatches \
+  #     -d '{"event_type":"extensions-changed"}'
+  repository_dispatch:
+    types: [extensions-changed]
+
+jobs:
+
+  Build:
+    name: "Pull"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'armbian' }}
+    steps:
+
+      - name: Checkout documentation
+        uses: actions/checkout@v7
+        with:
+          repository: 'armbian/documentation'
+          path: 'documentation'
+
+      - name: Checkout build repository
+        uses: actions/checkout@v7
+        with:
+          repository: 'armbian/build'
+          path: 'build'
+
+      - name: Generate extensions list
+        run: |
+          python3 build/lib/tools/gen-extensions-list.py \
+            > documentation/docs/build-framework/extensions/list.md
+
+      - name: Create Pull Request to documentation
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: documentation
+          commit-message: '`Automatic` extensions list update'
+          signoff: false
+          branch: auto-update-extensions-list
+          delete-branch: true
+          title: '`Automatic` extensions list update'
+          body: |
+            Regenerated `docs/build-framework/extensions/list.md` from the
+            `# @description` headers in `armbian/build` (`extensions/`).
+          labels: |
+            Needs review
+          draft: false


### PR DESCRIPTION
## What

Adds `.github/workflows/pull-extensions-list.yml`, which regenerates `docs/build-framework/extensions/list.md` from the `# @description` headers in `armbian/build` and opens a PR with the result.

- Checks out `armbian/documentation` + `armbian/build`
- Runs `python3 build/lib/tools/gen-extensions-list.py > documentation/docs/build-framework/extensions/list.md`
- Opens an auto-PR (`peter-evans/create-pull-request@v8`, branch `auto-update-extensions-list`, label `Needs review`)

## Triggers

- `workflow_dispatch` (manual)
- `repository_dispatch` type `extensions-changed`, sent from `armbian/build` after an extensions change

## Depends on

armbian/build#10534 — adds the `# @description` headers and `lib/tools/gen-extensions-list.py` that this workflow invokes. Merge that first.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1019"><kbd><br> Open WWW preview <br></kbd></a>