### PR TITLE
docs(software): drop emoji icons from "Why Use It"

### DIFF
--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -47,10 +47,10 @@ Installations may include hardware specific tuning for optimal performance.
 
 ## Why Use It
 
-- 🚀 **One-click deployments** of popular, containerized apps  
-- 🔒 **Curated, tested, and secure** software maintained by the Armbian community  
-- 🔁 **Clean installs and easy removal** — no system clutter or dependency hell  
-- 📦 **Optimized for Armbian-supported hardware**, with fine-tuned configurations  
-- ⚙️ **Minimal overhead**, ideal for embedded, headless, or remote systems  
-- 🛠️ **Easy maintenance** with integrated update and monitoring tools  
-- 🌐 **Internet-ready services**, including reverse proxies and network bridges
+- **One-click deployments** of popular, containerized apps  
+- **Curated, tested, and secure** software maintained by the Armbian community  
+- **Clean installs and easy removal** — no system clutter or dependency hell  
+- **Optimized for Armbian-supported hardware**, with fine-tuned configurations  
+- **Minimal overhead**, ideal for embedded, headless, or remote systems  
+- **Easy maintenance** with integrated update and monitoring tools  
+- **Internet-ready services**, including reverse proxies and network bridges


### PR DESCRIPTION
Removes the leading emoji (🚀 🔒 🔁 📦 ⚙️ 🛠️ 🌐) from each bullet in the **Why Use It** section of the software page, keeping the bold lead-ins and text.

The status marks (✅/⚠️) in the separate **Hardware Support** table are left as-is.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1022"><kbd><br> Open WWW preview <br></kbd></a>