### PR TITLE
docs(build-framework): add "How a build runs" page (#190, updated for armbian-next)

### DIFF
--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -20,7 +20,7 @@ This is a high-level tour of what `./compile.sh` does on a vanilla image build. 
     - if a matching build already exists, it is **downloaded** — no compilation;
     - otherwise the artifact is **built** (checkout source, apply the framework's patches then your `userpatches/` patches, compile to `.deb` / tarball) and **pushed** to the cache so the next build reuses it.
 
-5. **Root filesystem.** The rootfs is itself an artifact: pulled from cache when available, otherwise created with **`debootstrap`** for the target release (Debian or Ubuntu), then customized — Armbian packages, board support (`armbian-bsp-cli`), and the kernel/u-boot `.deb`s installed inside the chroot.
+5. **Root filesystem.** The rootfs is itself an artifact: pulled from cache when available, otherwise bootstrapped with **`mmdebstrap`** for the target release (Debian or Ubuntu), then customized — Armbian packages, board support (`armbian-bsp-cli`), and the kernel/u-boot `.deb`s installed inside the chroot.
 
 6. **Image assembly.** A raw image file is created on a **loop device**, partitioned and formatted, and the finished rootfs is copied in. Board- and family-specific **post-processing** then runs — for example writing u-boot to the right offset and assembling secondary program loaders.
 

--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -1,0 +1,37 @@
+---
+title: How a build runs
+seo_title: "How the Armbian build framework runs a build"
+description: "A high-level walkthrough of what the Armbian build framework does on a vanilla run: configuration aggregation, the artifact and remote-cache model, rootfs creation, and image assembly."
+---
+# How a build runs
+
+This is a high-level tour of what `./compile.sh` does on a vanilla image build. It is a mental model, not a line-by-line reference — the exact steps live in `lib/functions/` in the [build repository](https://github.com/armbian/build).
+
+## Order of operations
+
+1. **Entry and argument parsing.** `compile.sh` reads the command (e.g. `build`, `kernel-config`) and every `KEY=value` argument, turning each into the configuration variable used later.
+
+2. **Host preparation.** The framework runs inside a **Docker container by default** (`PREFER_DOCKER=yes`); it builds or pulls the build image, then installs host dependencies into it — including the **cross-toolchains, which are ordinary distribution packages** (gcc/binutils for the target architecture), not a collection Armbian ships itself. You can also build natively on a supported host.
+
+3. **Configuration aggregation.** Configuration is layered and inherited: **board → family → architecture → release**, merged with your `userpatches/` overrides and any enabled [extensions](extensions/index.md). The result is the complete set of variables — kernel source and branch, u-boot source, patch directories, package lists, and so on — that drives the rest of the build.
+
+4. **Artifacts (build-or-pull).** Each major component — **u-boot, kernel, firmware, `armbian-bsp-cli`, and the rootfs** — is an *artifact*. The framework computes a **content hash** from that artifact's inputs (git revision, patches, `.config`, framework code, variables), then:
+    - looks the hash up in the local cache and in the **remote OCI registry** (`ghcr.io/armbian/os`);
+    - if a matching build already exists, it is **downloaded** — no compilation;
+    - otherwise the artifact is **built** (checkout source, apply the framework's patches then your `userpatches/` patches, compile to `.deb` / tarball) and **pushed** to the cache so the next build reuses it.
+
+    This is the biggest difference from older Armbian: kernel and u-boot are not always compiled — they are fetched from cache whenever the inputs are unchanged.
+
+5. **Root filesystem.** The rootfs is itself an artifact: pulled from cache when available, otherwise created with **`debootstrap`** for the target release (Debian or Ubuntu), then customized — Armbian packages, board support (`armbian-bsp-cli`), and the kernel/u-boot `.deb`s installed inside the chroot.
+
+6. **Image assembly.** A raw image file is created on a **loop device**, partitioned and formatted, and the finished rootfs is copied in. Board- and family-specific **post-processing** then runs — for example writing u-boot to the right offset and assembling secondary program loaders.
+
+7. **Finalization.** The image is watermarked in **`/etc/armbian-release`**, checksums are generated, and the image is compressed.
+
+## Notes
+
+- **Kernel branches** are `legacy`, `current`, `edge`, and (for some boards) `vendor` — set with `BRANCH=`.
+- **Releases** are current Debian/Ubuntu codenames (for example `trixie`, `noble`), set with `RELEASE=`.
+- Individual stages can be run on their own — `kernel-config`, `kernel-patch`, `rewrite-kernel-config`, `artifact`, and others — which is how maintainers iterate without a full image build. See the [command reference](commands/index.md).
+
+*This page grew out of [documentation issue #190](https://github.com/armbian/documentation/issues/190), updated for the current (post-"armbian-next") framework.*

--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -13,7 +13,7 @@ This is a high-level tour of what `./compile.sh` does on a vanilla image build. 
 
 2. **Host preparation.** The framework runs inside a **Docker container by default** (`PREFER_DOCKER=yes`); it builds or pulls the build image, then installs host dependencies into it — including the **cross-toolchains, which are ordinary distribution packages** (gcc/binutils for the target architecture), not a collection Armbian ships itself. You can also build natively on a supported host.
 
-3. **Configuration aggregation.** Configuration is layered and inherited: **board → family → architecture → release**, merged with your `userpatches/` overrides and any enabled [extensions](extensions/index.md). The result is the complete set of variables — kernel source and branch, u-boot source, patch directories, package lists, and so on — that drives the rest of the build.
+3. **Configuration aggregation.** Configuration is layered and inherited: the **board** selects its **family**, then the family, common, and **architecture** defaults are sourced over it (each able to override the previous), merged with your `userpatches/` overrides and any enabled [extensions](extensions/index.md). The result is the complete set of variables — kernel source and branch, u-boot source, patch directories, package lists, and so on — that drives the rest of the build.
 
 4. **Artifacts (build-or-pull).** Each major component — **u-boot, kernel, firmware, `armbian-bsp-cli`, and the rootfs** — is an *artifact*. The framework computes a **content hash** from that artifact's inputs (git revision, patches, `.config`, framework code, variables), then:
     - looks the hash up in the local cache and in the **remote OCI registry** (`ghcr.io/armbian/os`);

--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -31,5 +31,3 @@ This is a high-level tour of what `./compile.sh` does on a vanilla image build. 
 - **Kernel branches** are `legacy`, `current`, `edge`, and (for some boards) `vendor` — set with `BRANCH=`.
 - **Releases** are current Debian/Ubuntu codenames (for example `trixie`, `noble`), set with `RELEASE=`.
 - Individual stages can be run on their own — `kernel-config`, `kernel-patch`, `rewrite-kernel-config`, `artifact`, and others — which is how maintainers iterate without a full image build. See the [command reference](commands/index.md).
-
-*This page grew out of [documentation issue #190](https://github.com/armbian/documentation/issues/190), updated for the current (post-"armbian-next") framework.*

--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -24,10 +24,18 @@ This is a high-level tour of what `./compile.sh` does on a vanilla image build. 
 
 6. **Image assembly.** A raw image file is created on a **loop device**, partitioned and formatted, and the finished rootfs is copied in. Board- and family-specific **post-processing** then runs — for example writing u-boot to the right offset and assembling secondary program loaders.
 
-7. **Finalization.** The image is watermarked in **`/etc/armbian-release`**, checksums are generated, and the image is compressed.
+7. **Finalization.** The image is watermarked in **`/etc/armbian-release`**, checksums and a fingerprint are written, and the image is compressed.
+
+## Where the output lands
+
+- **`output/images/`** — the finished (compressed) image plus its checksum and fingerprint files, and any extra formats.
+- **`output/debs/`** — the `.deb` packages that were built (kernel, u-boot, `armbian-*`).
+- **`output/logs/`** — the per-run build logs. Add `SHARE_LOG=yes` to upload them to `paste.armbian.com` when you ask for help.
 
 ## Notes
 
 - **Kernel branches** are `legacy`, `current`, `edge`, and (for some boards) `vendor` — set with `BRANCH=`.
 - **Releases** are current Debian/Ubuntu codenames (for example `trixie`, `noble`), set with `RELEASE=`.
 - Individual stages can be run on their own — `kernel-config`, `kernel-patch`, `rewrite-kernel-config`, `artifact`, and others — which is how maintainers iterate without a full image build. See the [command reference](commands/index.md).
+- Extra image formats (ISO, qcow2, VHDX, OVF, …) are produced by `image-output-*` [extensions](extensions/index.md), enabled with `ENABLE_EXTENSIONS=`.
+- Customization happens through **hooks**: [extensions](extensions/index.md) and your `userpatches/` attach to named points in the flow (patching, rootfs tweaks, image post-processing) without editing the framework.

--- a/docs/build-framework/how-a-build-runs.md
+++ b/docs/build-framework/how-a-build-runs.md
@@ -20,8 +20,6 @@ This is a high-level tour of what `./compile.sh` does on a vanilla image build. 
     - if a matching build already exists, it is **downloaded** — no compilation;
     - otherwise the artifact is **built** (checkout source, apply the framework's patches then your `userpatches/` patches, compile to `.deb` / tarball) and **pushed** to the cache so the next build reuses it.
 
-    This is the biggest difference from older Armbian: kernel and u-boot are not always compiled — they are fetched from cache whenever the inputs are unchanged.
-
 5. **Root filesystem.** The rootfs is itself an artifact: pulled from cache when available, otherwise created with **`debootstrap`** for the target release (Debian or Ubuntu), then customized — Armbian packages, board support (`armbian-bsp-cli`), and the kernel/u-boot `.deb`s installed inside the chroot.
 
 6. **Image assembly.** A raw image file is created on a **loop device**, partitioned and formatted, and the finished rootfs is copied in. Board- and family-specific **post-processing** then runs — for example writing u-boot to the right offset and assembling secondary program loaders.

--- a/docs/build-framework/index.md
+++ b/docs/build-framework/index.md
@@ -13,6 +13,8 @@ description: "Overview of the Armbian build framework: build custom kernels, boo
 
 ![Armbian build framework](../images/armbianbuildframework.png)
 
+For a step-by-step tour of what happens on a build — configuration, the artifact cache, rootfs and image assembly — see [**How a build runs**](how-a-build-runs.md).
+
 ## Key Advantages
 
 - Simplicity with interactive graphical interface.

--- a/docs/build-framework/index.md
+++ b/docs/build-framework/index.md
@@ -82,7 +82,7 @@ Function | Armbian | Yocto | Buildroot |
 ├── output                               Build artifact
 │   └── debs                             Deb packages
 │   └── images                           Bootable images - RAW or compressed
-│   └── debug                            Patch and build logs
+│   └── logs                             Build logs
 │   └── config                           Kernel configuration export location
 │   └── patch                            Created patches location
 ├── packages                             Support scripts, binary blobs, packages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -291,6 +291,7 @@ nav:
 #        - 'Desktops': 'User-Guide_Armbian-Software/Desktops.md'
   - 'ARMBIAN BUILD FRAMEWORK' :
         - 'Overview' : 'build-framework/index.md'
+        - 'How a build runs' : 'build-framework/how-a-build-runs.md'
         - 'Getting Started' : 'build-framework/getting-started.md'
         - 'Build Commands' :
             - 'Overview' : 'build-framework/commands/index.md'


### PR DESCRIPTION
Addresses [#190](https://github.com/armbian/documentation/issues/190) — the high-level "how the Armbian builder works" writeup. As the last commenter suspected, the original 14-step version predates *armbian-next*, so I **updated it** rather than pasting it.

## New dedicated page: `build-framework/how-a-build-runs.md`
Placed after **Overview** in the nav and linked from the overview intro.

### What changed vs the issue's version
- **Toolchains** — the framework no longer ships its own cross-toolchain collection; it installs the **distribution's** toolchain packages into the (default) **Docker** build container.
- **Artifacts / OCI cache** — added the biggest armbian-next change the old writeup missed: kernel, u-boot, firmware, `armbian-bsp-cli` and the rootfs are **content-hashed artifacts** pulled from the **`ghcr.io/armbian/os`** registry when their inputs are unchanged, and built + pushed otherwise. Kernel/u-boot are not always compiled.
- **Rootfs** as an artifact (debootstrap only on a cache miss).
- **Current names** — kernel branches `legacy/current/edge/vendor`, release codenames `trixie`/`noble`.

Kept it high-level (a mental model, not a line-by-line reference), matching the issue's intent. Credits the issue at the bottom.

Ref: #190

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1024"><kbd><br> Open WWW preview <br></kbd></a>