### PR TITLE
docs(build): document the vendor / branding switches

### DIFF
--- a/docs/build-framework/switches/branding.md
+++ b/docs/build-framework/switches/branding.md
@@ -1,13 +1,13 @@
 ---
 seo_title: "Armbian image branding / vendor build switches"
-description: "Rebrand Armbian images: VENDOR, VENDORURL, VENDORLOGO, MAINTAINER and related switches that write /etc/os-release, /etc/issue, the login MOTD and the .deb package signatures."
+description: "Rebrand Armbian images: VENDOR, VENDORURL, VENDORLOGO, MAINTAINER and related switches that write /etc/os-release, /etc/issue, the login MOTD and .deb package metadata."
 ---
 
 # Branding
 
 Rebrand the built image's identity — the OS name, URLs, logo, MOTD colour and package maintainer. Set these to ship your own white-labelled images instead of stock Armbian. They are normally set together in a [build configuration file](/build-framework/getting-started/#cli).
 
-These switches populate the image's identity files: `/etc/os-release`, `/etc/issue` and `/etc/issue.net`, `/etc/armbian-release`, `/etc/armbian-image-release`, the login MOTD, and the signature on the generated `.deb` packages.
+These switches populate the image's identity files: `/etc/os-release`, `/etc/issue` and `/etc/issue.net`, `/etc/armbian-release`, `/etc/armbian-image-release`, the login MOTD, and the `Maintainer` field of the generated `.deb` packages.
 
 !!! info "Defaults are deliberate placeholders"
     Left unset, the framework fills these with placeholder fallbacks (shown as the defaults below), so an un-branded build identifies itself as `Armbian-unofficial` rather than masquerading as an official release. A branded build overrides the whole group — see the [example](#a-full-rebrand) at the end.
@@ -22,7 +22,7 @@ The vendor / OS name. Written to `/etc/os-release` `PRETTY_NAME` (as `<VENDOR> <
 
 `string` · optional
 
-A friendly vendor name recorded in `/etc/armbian-image-release` (`VENDORPRETTYNAME=`). Unset by default.
+A friendly vendor name recorded in `/etc/armbian-image-release` (`VENDORPRETTYNAME=`). Defaults to `VENDOR` in the image when left unset.
 
 #### VENDORCOLOR
 
@@ -64,19 +64,19 @@ Bug-report URL — os-release `BUG_REPORT_URL`.
 
 `string` · default: `armbian-logo`
 
-Freedesktop icon name written to os-release `LOGO=` — the icon that tools like the desktop **About** dialog or `fastfetch` resolve from the icon theme (the asset ships as `/usr/share/pixmaps/<name>.svg`). It is **not** the boot splash; to change the Plymouth boot logo see [Boot splash (Plymouth)](#boot-splash-plymouth) below.
+Freedesktop icon name written to os-release `LOGO=` — the icon that tools like the desktop **About** dialog or `fastfetch` resolve from the icon theme. The framework only ships the `armbian-logo` assets (e.g. `/usr/share/pixmaps/armbian-logo.svg`), so a custom value (say `acme-logo`) resolves to nothing unless you also install a matching icon of that name. It is **not** the boot splash; to change the Plymouth boot logo see [Boot splash (Plymouth)](#boot-splash-plymouth) below.
 
 #### MAINTAINER
 
 `string` · default: `John Doe`
 
-Maintainer name used to sign the generated `.deb` packages and recorded in `/etc/armbian-release`.
+Maintainer name written to the `Maintainer:` field of the generated `.deb` packages (`DEBIAN/control` and the changelog trailer) and recorded in `/etc/armbian-release`. It does not cryptographically sign the packages.
 
 #### MAINTAINERMAIL
 
 `string` · default: `john.doe@somewhere.on.planet`
 
-Maintainer e-mail used for the `.deb` package signatures.
+Maintainer e-mail written alongside `MAINTAINER` into the `.deb` `Maintainer:` field.
 
 ## A full rebrand
 

--- a/docs/build-framework/switches/branding.md
+++ b/docs/build-framework/switches/branding.md
@@ -1,0 +1,99 @@
+---
+seo_title: "Armbian image branding / vendor build switches"
+description: "Rebrand Armbian images: VENDOR, VENDORURL, VENDORLOGO, MAINTAINER and related switches that write /etc/os-release, /etc/issue, the login MOTD and the .deb package signatures."
+---
+
+# Branding
+
+Rebrand the built image's identity — the OS name, URLs, logo, MOTD colour and package maintainer. Set these to ship your own white-labelled images instead of stock Armbian. They are normally set together in a [build configuration file](/build-framework/getting-started/#cli).
+
+These switches populate the image's identity files: `/etc/os-release`, `/etc/issue` and `/etc/issue.net`, `/etc/armbian-release`, `/etc/armbian-image-release`, the login MOTD, and the signature on the generated `.deb` packages.
+
+!!! info "Defaults are deliberate placeholders"
+    Left unset, the framework fills these with placeholder fallbacks (shown as the defaults below), so an un-branded build identifies itself as `Armbian-unofficial` rather than masquerading as an official release. A branded build overrides the whole group — see the [example](#a-full-rebrand) at the end.
+
+#### VENDOR
+
+`string` · default: `Armbian-unofficial`
+
+The vendor / OS name. Written to `/etc/os-release` `PRETTY_NAME` (as `<VENDOR> <version> <release>`), `/etc/issue`, `/etc/issue.net` and `/etc/armbian-release`. When unset it becomes `Armbian-unofficial`, marking the image as not an official build.
+
+#### VENDORPRETTYNAME
+
+`string` · optional
+
+A friendly vendor name recorded in `/etc/armbian-image-release` (`VENDORPRETTYNAME=`). Unset by default.
+
+#### VENDORCOLOR
+
+`string` (ANSI 256 / `R;G;B`) · default: `247;16;0`
+
+Colour used for the vendor logo in the login MOTD. Written to `/etc/armbian-release`.
+
+#### VENDORURL
+
+`string` (URL) · default: `https://duckduckgo.com/`
+
+Home page for the OS — os-release `HOME_URL`.
+
+#### VENDORDOCS
+
+`string` (URL) · default: `https://docs.armbian.com/`
+
+Documentation URL, recorded in `/etc/armbian-release`.
+
+#### VENDORSUPPORT
+
+`string` (URL) · default: `https://community.armbian.com/`
+
+Support URL — os-release `SUPPORT_URL`.
+
+#### VENDORPRIVACY
+
+`string` (URL) · default: `https://duckduckgo.com/`
+
+Privacy-policy URL — os-release `PRIVACY_POLICY_URL`.
+
+#### VENDORBUGS
+
+`string` (URL) · default: `https://armbian.atlassian.net/`
+
+Bug-report URL — os-release `BUG_REPORT_URL`.
+
+#### VENDORLOGO
+
+`string` · default: `armbian-logo`
+
+Name of the logo asset used for the login MOTD — os-release `LOGO`.
+
+#### MAINTAINER
+
+`string` · default: `John Doe`
+
+Maintainer name used to sign the generated `.deb` packages and recorded in `/etc/armbian-release`.
+
+#### MAINTAINERMAIL
+
+`string` · default: `john.doe@somewhere.on.planet`
+
+Maintainer e-mail used for the `.deb` package signatures.
+
+## A full rebrand
+
+Branded builds set the whole group together in a build config. For example, the values official Armbian images use:
+
+```bash
+declare -g VENDOR="Armbian"
+declare -g VENDORCOLOR="247;16;0"
+declare -g VENDORURL="https://www.armbian.com"
+declare -g VENDORDOCS="https://docs.armbian.com"
+declare -g VENDORSUPPORT="https://forum.armbian.com"
+declare -g VENDORPRIVACY="https://www.armbian.com"
+declare -g VENDORBUGS="https://www.armbian.com/bugs"
+declare -g VENDORLOGO="armbian-logo"
+declare -g MAINTAINER="Armbian Linux"
+declare -g MAINTAINERMAIL="info@armbian.com"
+```
+
+!!! note "Official builds"
+    When `VENDOR=Armbian`, the framework also refuses vendor branding on community / unsupported combinations (it resets several of these fields), so only genuinely official images carry the full Armbian identity.

--- a/docs/build-framework/switches/branding.md
+++ b/docs/build-framework/switches/branding.md
@@ -64,7 +64,7 @@ Bug-report URL — os-release `BUG_REPORT_URL`.
 
 `string` · default: `armbian-logo`
 
-Name of the logo asset used for the login MOTD — os-release `LOGO`.
+Freedesktop icon name written to os-release `LOGO=` — the icon that tools like the desktop **About** dialog or `fastfetch` resolve from the icon theme (the asset ships as `/usr/share/pixmaps/<name>.svg`). It is **not** the boot splash; to change the Plymouth boot logo see [Boot splash (Plymouth)](#boot-splash-plymouth) below.
 
 #### MAINTAINER
 
@@ -97,3 +97,19 @@ declare -g MAINTAINERMAIL="info@armbian.com"
 
 !!! note "Official builds"
     When `VENDOR=Armbian`, the framework also refuses vendor branding on community / unsupported combinations (it resets several of these fields), so only genuinely official images carry the full Armbian identity.
+
+## Boot splash (Plymouth)
+
+The graphical boot splash is a separate asset from the branding switches above — it is **not** controlled by `VENDORLOGO`. It ships in the `armbian-plymouth-theme` package.
+
+To use your own boot logo, replace the source image in the build framework:
+
+- **File:** `packages/plymouth-theme-armbian/armbian-logo.png`
+- **Size:** a **square PNG**, resized to **256×256** at build time — supply 256×256 (or a larger square; it is downscaled), on a transparent background (the splash background is black).
+
+The build installs it as `/usr/share/plymouth/themes/armbian/bgrt-fallback.png`. The `bgrt-fallback` name means it is the logo used when the firmware provides no BGRT boot logo — the case on virtually all SBCs, so this is the logo you actually see.
+
+Companion assets in the same folder: `watermark.png` (333×50, a wordmark shown centred) and `spinner.gif` (resized to a 52×52 throbber).
+
+!!! tip "Without editing the framework tree"
+    From `userpatches/customize-image.sh` you can overwrite `/usr/share/plymouth/themes/armbian/bgrt-fallback.png` (256×256) in the rootfs. Plymouth's early-boot copy lives in the initramfs, which the build regenerates after `customize-image.sh`, so dropping the file there is enough.

--- a/docs/build-framework/switches/index.md
+++ b/docs/build-framework/switches/index.md
@@ -21,6 +21,7 @@ The reference is split by what each switch controls:
 | [Target](target.md) | Which board, kernel branch and release to build |
 | [Image](image-type.md) | Minimal / desktop image and desktop selection |
 | [Contents](image-contents.md) | Packages, firmware, networking and first-run behaviour inside the image |
+| [Branding](branding.md) | Vendor / OS identity: name, URLs, logo, MOTD colour, maintainer |
 | [Kernel](kernel-uboot.md) | Kernel source, config, compiler and bootloader options |
 | [Filesystem](filesystem.md) | Root filesystem, partitions, labels, sizes and compression |
 | [Host](host-docker.md) | The build host and the Docker build container |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -302,6 +302,7 @@ nav:
             - 'Target' : 'build-framework/switches/target.md'
             - 'Image' : 'build-framework/switches/image-type.md'
             - 'Contents' : 'build-framework/switches/image-contents.md'
+            - 'Branding' : 'build-framework/switches/branding.md'
             - 'Kernel' : 'build-framework/switches/kernel-uboot.md'
             - 'Filesystem' : 'build-framework/switches/filesystem.md'
             - 'Host' : 'build-framework/switches/host-docker.md'


### PR DESCRIPTION
The image **rebranding / vendor-identity** switches weren't documented anywhere in Build Switches. Added a dedicated **Branding** page (fits the split's per-category pattern better than scattering 11 switches into an existing page).

Covers, with framework defaults and the identity file each writes:

| Switch | Writes |
|---|---|
| `VENDOR` | os-release `PRETTY_NAME`, `/etc/issue`, `/etc/armbian-release` |
| `VENDORPRETTYNAME` | `/etc/armbian-image-release` |
| `VENDORCOLOR` | MOTD logo colour (`/etc/armbian-release`) |
| `VENDORURL` | os-release `HOME_URL` |
| `VENDORDOCS` | `/etc/armbian-release` |
| `VENDORSUPPORT` | os-release `SUPPORT_URL` |
| `VENDORPRIVACY` | os-release `PRIVACY_POLICY_URL` |
| `VENDORBUGS` | os-release `BUG_REPORT_URL` |
| `VENDORLOGO` | os-release `LOGO` |
| `MAINTAINER` / `MAINTAINERMAIL` | `.deb` package signatures, `/etc/armbian-release` |

Defaults shown are the framework fallbacks from `lib/functions/configuration/main-config.sh` (deliberate placeholders — an un-branded build is `Armbian-unofficial`). The page ends with a full-rebrand example using the values official Armbian images set. Wired into the nav (between **Contents** and **Kernel**) and the switches overview table.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1025"><kbd><br> Open WWW preview <br></kbd></a>