### PR TITLE
docs(build): document four more user-facing switches

### DIFF
--- a/docs/build-framework/switches/branding.md
+++ b/docs/build-framework/switches/branding.md
@@ -78,6 +78,12 @@ Maintainer name written to the `Maintainer:` field of the generated `.deb` packa
 
 Maintainer e-mail written alongside `MAINTAINER` into the `.deb` `Maintainer:` field.
 
+#### PLYMOUTH
+
+`string` · default: `yes`
+
+Builds and installs the Plymouth graphical boot splash (the `armbian-plymouth-theme` package). Set `no` to skip it for a text-only boot or a smaller image. It is forced `no` when the board has no video output (`HAS_VIDEO_OUTPUT=no`). See [Boot splash (Plymouth)](#boot-splash-plymouth) for customising the logo.
+
 ## A full rebrand
 
 Branded builds set the whole group together in a build config. For example, the values official Armbian images use:

--- a/docs/build-framework/switches/filesystem.md
+++ b/docs/build-framework/switches/filesystem.md
@@ -129,6 +129,12 @@ Size in MB of a separate `/boot` partition, created when the root filesystem can
 
 Forces the output image to a fixed size in megabytes instead of the default behaviour, where the build makes the image just large enough to hold the root filesystem. Set it when you need a predictable image size — for example to fit a specific card, to leave free space for later growth, or because a filesystem such as f2fs requires a pre-sized image and the build will refuse to continue without it.
 
+#### EXTRA_ROOTFS_MIB_SIZE
+
+`integer` · default: `0`
+
+Adds this many MiB of free space to the root filesystem partition, on top of the size the build calculates from the rootfs contents. Use it when the default headroom is too tight — for packages added at first boot, logs or data — without pinning the whole image to a fixed size the way `FIXED_IMAGE_SIZE` does.
+
 #### BOOT_FS_LABEL
 
 `string` · default: `armbi_boot`

--- a/docs/build-framework/switches/image-contents.md
+++ b/docs/build-framework/switches/image-contents.md
@@ -102,6 +102,12 @@ NTP server used to synchronise the clock on the **build host** during preparatio
 
 Automatically logs in as root on the local serial/HDMI console at first boot, so a freshly flashed board is immediately usable without a keyboard-and-password step. Set `no` if your security threat model requires a login prompt on the physical console.
 
+#### ROOTPWD
+
+`string` · default: `1234`
+
+Presets the root account password baked into the image. The default `1234` is a placeholder that the first-run flow flags for change at first login; set your own for automated or kiosk deployments. Treat it as a secret — it is written into the image, so prefer a build config file or a CI secret over passing it on the command line.
+
 #### OPENSSHD_REGENERATE_HOST_KEYS
 
 `boolean`

--- a/docs/build-framework/switches/target.md
+++ b/docs/build-framework/switches/target.md
@@ -48,3 +48,9 @@ Set the userspace release base manually to skip the dialog prompt. Each release 
 
 !!! tip "Note"
     Only stable and/or LTS upstream Debian or Ubuntu releases are officially supported. Others might work or not.
+
+#### IMAGE_VERSION
+
+`string` · default: the computed `REVISION`
+
+Overrides the version string embedded in the output: the image filename (`<VENDOR>_<IMAGE_VERSION>_<board>_<release>_...`) and the on-image identity (`/etc/issue`, `/etc/os-release`). Leave it unset to use the framework's computed revision; set it to stamp your own version scheme onto custom builds.


### PR DESCRIPTION
From a scan of the build framework for user-settable switches missing from the reference. Each was verified against the code (current, user-facing, real default) before adding.

| Switch | Page | Default | Role |
|---|---|---|---|
| `EXTRA_ROOTFS_MIB_SIZE` | Filesystem | `0` | Extra free MiB added to the rootfs partition (`partitioning.sh`) |
| `ROOTPWD` | Contents | `1234` | Preset root password baked into the image |
| `IMAGE_VERSION` | Target | computed `REVISION` | Override the version string in the image filename + on-image identity |
| `PLYMOUTH` | Branding | `yes` | Toggle the Plymouth boot splash; forced `no` when `HAS_VIDEO_OUTPUT=no`; links to the existing boot-splash section |

**`ENABLE_EXTENSIONS`** (the cross-reference item) turned out to be **already documented** on the Contents page with a link to the Extensions reference, so no change was needed.

Excluded after verification (not general user switches): `SKIP_IMAGES` (info/CI-matrix only), `WITH_GRUB` (single board), `EXTERNAL_NEW` (not ported to armbian-next), `CROSS_COMPILE` (internal make var).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1026"><kbd><br> Open WWW preview <br></kbd></a>