### PR TITLE
docs: address post-merge CodeRabbit review nits

### DIFF
--- a/docs/community/chat.md
+++ b/docs/community/chat.md
@@ -70,7 +70,7 @@ Besides the services offered by IRC (like Nickserv or Chanserv) Armbian has set 
 ## ❔ FAQ
 
 - Why are there so many people in the channel and nobody is talking?  
-  - It is pretty common for community IRC channels for people to simply *idle* there. Many also using so called [IRC bouncers](https://en.wikipedia.org/wiki/BNC_(software)) that keeps their connection to the channel alive to act like an answering machine.
+  - It is pretty common for community IRC channels for people to simply *idle* there. Many also use so-called [IRC bouncers](https://en.wikipedia.org/wiki/BNC_(software)) that keep their connection to the channel alive to act like an answering machine.
 
 - I wrote 'Hi' but nobody answered. How do I get support there?
   - Probably there is nobody around at the time. Keep in mind that all users are spread around the globe and therefore living in many different time zones.  
@@ -92,4 +92,4 @@ Besides the services offered by IRC (like Nickserv or Chanserv) Armbian has set 
 
 ## 👉 Bottom line
 
-If you have any questions, comments regarding the IRC channels and/or services or found an issue in this documentation or think you can enhance it, get in touch with *Werner* either via [forums](https://forum.armbian.com/profile/9032-werner/), IRC or Discord.
+If you have questions or comments about the IRC channels and services, have found an issue in this documentation, or think you can enhance it, get in touch with *Werner* either via [forums](https://forum.armbian.com/profile/9032-werner/), IRC or Discord.

--- a/docs/contribute/armbian-config.md
+++ b/docs/contribute/armbian-config.md
@@ -120,15 +120,17 @@ function module_template() {
 
 #### Manual testing
 
-Whenever you are making changes to the JSON or modules structure, make sure to join JSON segments into main JSON file and run. This you do with a command:
-``` python
+Whenever you are making changes to the JSON or modules structure, make sure to join the JSON segments into the main JSON file. Run the following command:
+
+~~~ python
 tools/config-assemble.sh -p
-```
+~~~
+
 Python is required to run this tool.
 
-``` bash
+~~~ bash
 sudo bin/armbian-config --cmd
-```
+~~~
 
 #### Unit tests
 

--- a/docs/contribute/board-maintainer.md
+++ b/docs/contribute/board-maintainer.md
@@ -39,7 +39,7 @@ If something does not work, this is fine and normal. The important part is that 
 
 Ideally you have multiple microSD cards laying around to test regular updates on current releases and nightly without having to re-flash the same card every time to switch between branches.
 
-Alternatively you can use auto-built images - they are placed at the very end of each board download pages under "Rolling releases".
+Alternatively you can use auto-built images - they are placed at the very end of each board download page under "Rolling releases".
 
 - You must provide "best effort" support in the forum. Do not let that wording intimidate you. This is not a complicated task. Regarding forums this can include things like answering obvious questions (for example by pointing to our documentation, ideally directly to the solution page), let the questioner know that additional information is needed for further debugging (e.g. request "armbianmonitor -u" output) or for upgrade issues, ask if they can recreate the issue with a fresh untouched image from: <https://www.armbian.com/download/>
 


### PR DESCRIPTION
Follow-up to #1027, addressing the four CodeRabbit comments posted just after it merged.

- **community/chat** — fix subject-verb agreement and hyphenate `so-called` in the IRC-bouncers FAQ answer; make the contact sentence's `If`-clause conditions grammatically parallel.
- **board-maintainer** — `each board download pages` → `each board download page`.
- **contribute/armbian-config** — make the manual-testing block lint-clean (blank lines around the fenced blocks, tilde fences, and "Run the following command").

All are minor "quick win" grammar/lint nits — no content or link changes.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1028"><kbd><br> Open WWW preview <br></kbd></a>