### PR TITLE
ci(mirrors): let site names wrap to stop the table overflowing

### DIFF
--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -103,7 +103,7 @@ jobs:
             SITEQ=$(curl -s -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" \
                           -H "Accept: application/json; indent=4" \
                           "${{ secrets.NETBOX_API }}/dcim/sites/?limit=500&name__empty=false&id=$SITE_ID")
-            SITE_NAME=$(echo $SITEQ | jq -r ".results[] | select(.id == $SITE_ID) | .name" | sed 's/ /\&nbsp;/g')
+            SITE_NAME=$(echo $SITEQ | jq -r ".results[] | select(.id == $SITE_ID) | .name")
             SITE_REGION=$(echo $SITEQ | jq -r ".results[] | select(.id == $SITE_ID) | .region.display")
             SITE_REGION_SLUG=$(echo $SITEQ | jq -r ".results[] | select(.id == $SITE_ID) | .region.slug // empty")
             SITE_LATITUDE=$(echo $SITEQ | jq ".results[] | select(.id == $SITE_ID) | .latitude")


### PR DESCRIPTION
The Current Mirrors table renders with a horizontal scrollbar because it is wider than the content column. The main cause is that the generator replaced every space in a site name with `&nbsp;`:

```
SITE_NAME=$(... .name | sed 's/ /\&nbsp;/g')
```

That stops long names (e.g. *Qilu University of Technology*, *SBC mirror Singapore*) from wrapping, stretching the Site column and pushing the whole table past the page width. Removing the substitution lets the column wrap so the table fits. Combined with the column trim in #1029, the table should no longer overflow.

On merge, the push triggers the workflow and the live table regenerates with wrapping names.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1031"><kbd><br> Open WWW preview <br></kbd></a>