### PR TITLE
docs(mirrors): lead with the mirror list; splice generator by markers

### DIFF
--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -22,45 +22,14 @@ jobs:
           repository: 'armbian/documentation'
           path: 'documentation'
 
-      - name: Update rsync section
-        run: |
-          FILE="documentation/docs/contribute/mirrors.md"
-          sed '/^### 2\. Set up synchronization via rsync/,$d' "$FILE" > tmp.md
-          cat <<EOF >> tmp.md
-          ### 2. Set up synchronization via rsync
-
-            - Sync files from one of the official repositories using the following commands:
-
-            | Content         | Command                                     | Required Space |
-            |-----------------|---------------------------------------------|---------------:|
-          EOF
-          for storage in dl apt archive oldarchive; do
-            size=$(curl -s https://fi.mirror.armbian.de/$storage/size.txt)
-            case "$storage" in
-              "dl")
-                TEXT="Current images"
-                ;;
-              "apt")
-                TEXT="Packages"
-                ;;
-              "archive")
-                TEXT="Archived images"
-                ;;
-              *)
-                TEXT="Very old images"
-                ;;
-            esac
-            echo "   | $TEXT | \`rsync -av rsync://fi.mirror.armbian.de/$storage\` | $size |" >> tmp.md
-          done
-          sed -n '/^## Current Mirrors/,$p' "$FILE" >> tmp.md
-          sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' tmp.md
-          mv tmp.md "$FILE"
-  
       - name: Update Current Mirrors section
         run: |
           FILE="documentation/docs/contribute/mirrors.md"
-          sed '/^## Current Mirrors/,$d' "$FILE" > tmp.md
-          cat <<EOF >> tmp.md
+          # Build the replacement block (markers included). It is spliced back
+          # into the page between the mirrors:start / mirrors:end markers, so
+          # the table can live anywhere in the file, not just at the end.
+          cat <<EOF > block.md
+          <!-- mirrors:start -->
           ## Current Mirrors
 
           | Site | Flag | Packages | Images | Archive | Rsync |
@@ -134,13 +103,21 @@ jobs:
             else
               FLAG_CELL="[$SITE_REGION](https://www.openstreetmap.org/search?lat=$SITE_LATITUDE&lon=$SITE_LONGITUDE)"
             fi
-            echo "| [$SITE_NAME](https://$NAME) | $FLAG_CELL | $FIELD1 | $FIELD2 | $FIELD3 | $FIELD4 |" >> tmp.md
+            echo "| [$SITE_NAME](https://$NAME) | $FLAG_CELL | $FIELD1 | $FIELD2 | $FIELD3 | $FIELD4 |" >> block.md
           done
-          sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' tmp.md
-          mv tmp.md "$FILE"
+          echo '<!-- mirrors:end -->' >> block.md
+
+          # Splice the freshly built block back in, replacing the current
+          # marker-delimited region wherever it sits in the page.
+          awk -v bf=block.md '
+            BEGIN { while ((getline l < bf) > 0) B = B l ORS }
+            /<!-- mirrors:start -->/ { printf "%s", B; skip=1; next }
+            /<!-- mirrors:end -->/   { skip=0; next }
+            !skip { print }
+          ' "$FILE" > tmp.md && mv tmp.md "$FILE"
 
           # Surface the rendered mirror table in the workflow run summary.
-          sed -n '/^## Current Mirrors/,$p' "$FILE" >> "$GITHUB_STEP_SUMMARY"
+          cat block.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create Pull Request to documentation
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -13,6 +13,9 @@ jobs:
   Build:
     name: "Pull"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ github.repository_owner == 'armbian' }}
     steps:
 
@@ -106,6 +109,19 @@ jobs:
             echo "| [$SITE_NAME](https://$NAME) | $FLAG_CELL | $FIELD1 | $FIELD2 | $FIELD3 | $FIELD4 |" >> block.md
           done
           echo '<!-- mirrors:end -->' >> block.md
+
+          # Fail closed: require exactly one start marker, exactly one end
+          # marker, and start before end. Otherwise the splice below could
+          # wipe everything after the start marker (missing end) or silently
+          # do nothing (missing start), so refuse to touch the file.
+          starts=$(grep -c '<!-- mirrors:start -->' "$FILE" || true)
+          ends=$(grep -c '<!-- mirrors:end -->' "$FILE" || true)
+          sline=$(grep -n '<!-- mirrors:start -->' "$FILE" | head -1 | cut -d: -f1)
+          eline=$(grep -n '<!-- mirrors:end -->' "$FILE" | head -1 | cut -d: -f1)
+          if [ "$starts" -ne 1 ] || [ "$ends" -ne 1 ] || [ "${sline:-0}" -ge "${eline:-0}" ]; then
+            echo "::error::mirrors markers invalid in $FILE (start=$starts end=$ends order=$sline/$eline); aborting without changes"
+            exit 1
+          fi
 
           # Splice the freshly built block back in, replacing the current
           # marker-delimited region wherever it sits in the page.

--- a/docs/contribute/mirrors.md
+++ b/docs/contribute/mirrors.md
@@ -5,45 +5,9 @@ comments: true
 ---
 # How the Armbian mirror system works
 
-The [Armbian mirror system](https://github.com/armbian/armbian-router) distributes files efficiently, routing each user to the best available server by geographic proximity and server health. This page explains how it works, what a mirror needs to provide, and how to contribute one.
+The [Armbian mirror system](https://github.com/armbian/armbian-router) distributes files efficiently, routing each user to the best available server by geographic proximity and server health. Pick a nearby mirror from the list below, or read on for how the system works and how to contribute one.
 
-![armbian-mirror-explication](../images/armbian-mirror-explication.png)
-
-## How it works
-
-1. **Request** — a user starts a download (image, package, ...) from a standard URL such as `https://dl.armbian.com`.
-2. **Routing** — the redirector picks the best mirror based on the user's location, each mirror's status and load, and whether it holds the requested file.
-3. **Redirect** — the user is sent straight to the chosen mirror.
-4. **Download** — the file is served directly from that mirror, keeping downloads fast and taking load off the core infrastructure.
-
-The result is **load balancing** across many servers, **faster downloads** from a nearby mirror, and **redundancy** — if a mirror is unavailable, the redirector automatically routes around it.
-
-## Contribute a mirror
-
-If you can host a mirror for the project, here is how.
-
-### 1. Set up an HTTP(S) host
-
-The mirror must be reachable over HTTPS (plain HTTP is also accepted). Point a hostname at it before you start syncing.
-
-### 2. Sync with `rsync`
-
-Pull the content you want to serve from one of the official modules, and run it from cron every **2-4 hours**:
-
-| Content | Command | Required space |
-|---------|---------|---------------:|
-| Current images | `rsync -av rsync://rsync.armbian.com/dl` | 556G |
-| Packages | `rsync -av rsync://rsync.armbian.com/apt` | 84G |
-| Archived images | `rsync -av rsync://rsync.armbian.com/archive` | 1.9T |
-| Very old images | `rsync -av rsync://rsync.armbian.com/oldarchive` | 5.4T |
-
-### 3. Tell us about it
-
-Once the server is running, reach out through the [contact form](https://www.armbian.com/contact/) so we can add it to the official redirector.
-
-Thanks for helping keep Armbian's downloads fast and reliable worldwide.
-
-
+<!-- mirrors:start -->
 ## Current Mirrors
 
 | Site | Flag | Packages | Images | Archive | Rsync |
@@ -93,3 +57,40 @@ Thanks for helping keep Armbian's downloads fast and reliable worldwide.
 | [SBC mirror Singapore](https://sg.sbcmirror.org) | [![Singapore](https://flagsapi.com/SG/shiny/32.png)](https://www.openstreetmap.org/search?lat=1.3673&lon=103.8014) | :white_check_mark: | :white_check_mark: |  |  |
 | [JetHome](https://stpete-mirror.armbian.com) | [![Russia](https://flagsapi.com/RU/shiny/32.png)](https://www.openstreetmap.org/search?lat=59.9417&lon=30.3096) | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
 | [Xogium](https://xogium.performanceservers.nl) | [![France](https://flagsapi.com/FR/shiny/32.png)](https://www.openstreetmap.org/search?lat=48.5144&lon=-2.768) | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
+<!-- mirrors:end -->
+
+## How it works
+
+![armbian-mirror-explication](../images/armbian-mirror-explication.png)
+
+1. **Request** — a user starts a download (image, package, ...) from a standard URL such as `https://dl.armbian.com`.
+2. **Routing** — the redirector picks the best mirror based on the user's location, each mirror's status and load, and whether it holds the requested file.
+3. **Redirect** — the user is sent straight to the chosen mirror.
+4. **Download** — the file is served directly from that mirror, keeping downloads fast and taking load off the core infrastructure.
+
+The result is **load balancing** across many servers, **faster downloads** from a nearby mirror, and **redundancy** — if a mirror is unavailable, the redirector automatically routes around it.
+
+## Contribute a mirror
+
+If you can host a mirror for the project, here is how.
+
+### 1. Set up an HTTP(S) host
+
+The mirror must be reachable over HTTPS (plain HTTP is also accepted). Point a hostname at it before you start syncing.
+
+### 2. Sync with `rsync`
+
+Pull the content you want to serve from one of the official modules, and run it from cron every **2-4 hours**:
+
+| Content | Command | Required space |
+|---------|---------|---------------:|
+| Current images | `rsync -av rsync://rsync.armbian.com/dl` | 556G |
+| Packages | `rsync -av rsync://rsync.armbian.com/apt` | 84G |
+| Archived images | `rsync -av rsync://rsync.armbian.com/archive` | 1.9T |
+| Very old images | `rsync -av rsync://rsync.armbian.com/oldarchive` | 5.4T |
+
+### 3. Tell us about it
+
+Once the server is running, reach out through the [contact form](https://www.armbian.com/contact/) so we can add it to the official redirector.
+
+Thanks for helping keep Armbian's downloads fast and reliable worldwide.


### PR DESCRIPTION
Puts the **Current Mirrors** list first on the [mirrors page](docs/contribute/mirrors.md) — it's what most visitors are after.

**Page**
- Order is now: intro → **Current Mirrors** table → *How it works* (the flow diagram moves here, where it's relevant) → *Contribute a mirror*.
- The table is wrapped in `<!-- mirrors:start -->` / `<!-- mirrors:end -->` markers.

**Workflow** (`pull-mirrors-from-db.yml`)
- The generator used to delete everything from `## Current Mirrors` to EOF and re-append — which only works when the table is last. It now builds the table into a block and **splices it into the marker region with awk**, so the table can sit anywhere in the page.
- Dropped the long-dead *Update rsync section* step: its heading anchor (`### 2. Set up synchronization via rsync`) never matched the actual `` ### 2. Sync with `rsync` `` heading, so it only ever appended output the next step discarded. The rsync sync sizes stay as maintained prose.

Tested the awk splice locally against the restructured page: the marker region is replaced and every prose section (How it works, Contribute, rsync table, closing) is preserved. On merge, the workflow run regenerates the block in place.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1034"><kbd><br> Open WWW preview <br></kbd></a>