### PR TITLE
feat(tools): apt.armbian.com status report with kernel-drift summary at PR stage

### DIFF
--- a/.github/workflows/apt-repo-status.yml
+++ b/.github/workflows/apt-repo-status.yml
@@ -1,0 +1,41 @@
+name: "apt.armbian.com status"
+
+# Surfaces a status summary of the apt.armbian.com repository — package
+# versions and, notably, which kernel families lag the current release — in
+# the run's job summary, so it is visible directly at PR stage.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/apt-repo-status.py'
+      - '.github/workflows/apt-repo-status.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    name: "Repository status"
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'armbian' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install python3-apt (accurate Debian version comparison)
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends python3-apt
+
+      - name: Generate apt repository status
+        run: |
+          python3 tools/apt-repo-status.py --kernels --output apt-status.md
+          cat apt-status.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Markdown report
+        uses: actions/upload-artifact@v4
+        with:
+          name: apt-repo-status
+          path: apt-status.md
+          if-no-files-found: error

--- a/tools/apt-repo-status.py
+++ b/tools/apt-repo-status.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Generate a Markdown status report for the apt.armbian.com repository.
+
+Runs locally, downloads the repository indices and prints Markdown to stdout
+(or --output FILE) that can be pasted / spliced into the documentation.
+
+Examples:
+    tools/apt-repo-status.py                 # arm64, component main, all suites
+    tools/apt-repo-status.py --arch amd64
+    tools/apt-repo-status.py --suites bookworm trixie noble --output status.md
+"""
+import argparse
+import gzip
+import io
+import re
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_BASE = "https://apt.armbian.com"
+
+# Active / supported suites shown by default (override with --suites, or --all).
+DEFAULT_SUITES = ["bookworm", "trixie", "sid", "jammy", "noble"]
+
+# Armbian's own non board-specific packages (component `main`).
+CORE_PACKAGES = [
+    "armbian-firmware",
+    "armbian-firmware-full",
+    "armbian-zsh",
+    "armbian-plymouth-theme",
+]
+# Kernel branches to summarise (in display order); anything else is "other".
+KERNEL_BRANCHES = ["current", "edge", "legacy", "vendor"]
+
+
+def util_family(name):
+    """Fold split/variant util packages into one representative family row."""
+    if name.startswith("zulu"):
+        return re.match(r"(zulu\d+)", name).group(1) + " (JDK)"
+    if re.match(r"^(zfs|libzfs|libzpool|libnvpair|libuutil)", name):
+        return "zfs (OpenZFS)"
+    if name.startswith("libraspberrypi"):
+        return "libraspberrypi"
+    if name.startswith("python3-libcamera"):
+        return "libcamera"
+    return name
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "armbian-apt-status/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read()
+
+
+# --- Debian version comparison -------------------------------------------------
+try:
+    import apt_pkg
+    apt_pkg.init_system()
+
+    def version_gt(a, b):
+        return apt_pkg.version_compare(a, b) > 0
+except Exception:
+    def _split(v):
+        # crude but serviceable fallback: split into numeric / non-numeric runs
+        import re
+        parts = re.findall(r"\d+|\D+", v)
+        key = []
+        for p in parts:
+            key.append((0, int(p)) if p.isdigit() else (1, p))
+        return key
+
+    def version_gt(a, b):
+        return _split(a) > _split(b)
+
+
+def version_max(versions):
+    best = None
+    for v in versions:
+        if best is None or version_gt(v, best):
+            best = v
+    return best
+
+
+# --- Repository access ---------------------------------------------------------
+def discover_suites(base):
+    try:
+        html = fetch(base + "/dists/").decode("utf-8", "replace")
+    except Exception:
+        return []
+    import re
+    out = []
+    for m in re.findall(r'href="([^"?/]+)/"', html):
+        if m not in ("..", ".") and m not in out:
+            out.append(m)
+    return out
+
+
+def get_release(base, suite):
+    try:
+        text = fetch(f"{base}/dists/{suite}/Release").decode("utf-8", "replace")
+    except Exception:
+        return {}
+    fields = {}
+    for line in text.splitlines():
+        if line and not line[0].isspace() and ":" in line:
+            k, _, v = line.partition(":")
+            fields[k.strip()] = v.strip()
+    return fields
+
+
+def get_packages(base, suite, component, arch):
+    """Return list of {Package, Version, Architecture, Section} stanzas."""
+    url = f"{base}/dists/{suite}/{component}/binary-{arch}/Packages.gz"
+    try:
+        raw = fetch(url)
+    except Exception:
+        return None
+    data = gzip.GzipFile(fileobj=io.BytesIO(raw)).read().decode("utf-8", "replace")
+    stanzas = []
+    cur = {}
+    for line in data.splitlines():
+        if not line.strip():
+            if cur:
+                stanzas.append(cur)
+                cur = {}
+            continue
+        if line[0].isspace() or ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        cur[k.strip()] = v.strip()
+    if cur:
+        stanzas.append(cur)
+    return stanzas
+
+
+# --- Report --------------------------------------------------------------------
+def build_report(base, suites, component, arch, kernels=False):
+    out = []
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    out.append("## Armbian apt repository status")
+    out.append("")
+    out.append(f"_Generated {now} from [`{base}`]({base}) "
+               f"— component `{component}`, architecture `{arch}`._")
+    out.append("")
+
+    def latest_map(stanzas):
+        latest = {}
+        for st in stanzas or []:
+            name, ver = st.get("Package"), st.get("Version")
+            if not name or not ver:
+                continue
+            if name not in latest or version_gt(ver, latest[name]):
+                latest[name] = ver
+        return latest
+
+    suite_data = {}
+    for suite in suites:
+        rel = get_release(base, suite)
+        pkgs = get_packages(base, suite, component, arch)
+        if pkgs is None:
+            continue
+        latest = latest_map(pkgs)
+        # 3rd-party / utility tools live in the suite-prefixed "-utils" component.
+        utils = latest_map(get_packages(base, suite, f"{suite}-utils", arch))
+        suite_data[suite] = {"release": rel, "latest": latest,
+                             "count": len(latest), "utils": utils}
+
+    # --- Suite overview
+    out.append("### Suites")
+    out.append("")
+    out.append("| Suite | Codename | Updated | Packages | Latest Armbian version |")
+    out.append("|:------|:---------|:--------|--------:|:----------------------|")
+    for suite in suites:
+        d = suite_data.get(suite)
+        if not d:
+            continue
+        rel = d["release"]
+        updated = rel.get("Date", "—")[:16]
+        newest = version_max(d["latest"].values()) or "—"
+        out.append(f"| `{suite}` | {rel.get('Codename', suite)} | {updated} "
+                   f"| {d['count']} | `{newest}` |")
+    out.append("")
+
+    active = [s for s in suites if s in suite_data]
+
+    # Armbian's `main` content is identical across suites, so merge it into a
+    # single view (newest version seen for each package across all suites).
+    merged = {}
+    for suite in active:
+        for name, ver in suite_data[suite]["latest"].items():
+            if name not in merged or version_gt(ver, merged[name]):
+                merged[name] = ver
+
+    # --- Core packages (single column — same across every suite)
+    out.append("### Core package versions")
+    out.append("")
+    out.append("Armbian's own base packages (component `main`) — identical across all suites.")
+    out.append("")
+    out.append("| Package | Version |")
+    out.append("|:--------|:--------|")
+    for pkg in CORE_PACKAGES:
+        v = merged.get(pkg)
+        out.append(f"| `{pkg}` | {('`'+v+'`') if v else '—'} |")
+    out.append("")
+
+    # --- Kernel branches (distinct families + newest version per branch)
+    out.append("### Kernel branches")
+    out.append("")
+    out.append("Distinct kernel families and the newest Armbian version published "
+               "per branch (from `linux-image-<branch>-*`).")
+    out.append("")
+    out.append("| Branch | Families | Latest version |")
+    out.append("|:-------|--------:|:--------------|")
+    for branch in KERNEL_BRANCHES:
+        fams, vers = set(), []
+        for name, ver in merged.items():
+            if name.startswith(f"linux-image-{branch}-"):
+                fams.add(name)
+                vers.append(ver)
+        if fams:
+            out.append(f"| {branch} | {len(fams)} | `{version_max(vers)}` |")
+        else:
+            out.append(f"| {branch} | 0 | — |")
+    out.append("")
+
+    # --- Per-family kernel drift (opt-in): every family, newest version, and
+    #     whether it lags the current release. Answers "which kernels drift".
+    if kernels:
+        fam_latest = {n: v for n, v in merged.items() if n.startswith("linux-image-")}
+        ref = version_max(fam_latest.values())
+        rows = []
+        for name, ver in fam_latest.items():
+            parts = name.split("-")           # linux-image-<branch>-<family...>
+            branch = parts[2] if len(parts) > 2 else "?"
+            family = "-".join(parts[3:]) if len(parts) > 3 else "?"
+            rows.append((version_gt(ref, ver), branch, family, ver))
+        n_behind = sum(1 for r in rows if r[0])
+        out.append("### Kernel families")
+        out.append("")
+        out.append(f"Newest version published per kernel family. The current release "
+                   f"line is `{ref}`; families below it were not rebuilt for it.")
+        out.append("")
+        out.append(f"**{n_behind} of {len(rows)} families behind `{ref}`.**")
+        out.append("")
+        out.append("| Branch | Family | Version | Status |")
+        out.append("|:-------|:-------|:--------|:-------|")
+        # behind families first (most useful), then by branch and family name
+        for behind, branch, family, ver in sorted(rows, key=lambda r: (not r[0], r[1], r[2])):
+            status = f"⚠️ behind `{ref}`" if behind else "✅ current"
+            out.append(f"| {branch} | `{family}` | `{ver}` | {status} |")
+        out.append("")
+
+    # --- Third-party / utility packages (the "-utils" component), per suite,
+    #     with split/variant packages folded into one family row.
+    out.append("### Third-party & utility packages")
+    out.append("")
+    out.append("Upstream tools imported per suite (component `<suite>-utils`); "
+               "split families (JDK, OpenZFS, ...) are folded to their newest member, "
+               "and `-dbgsym` debug packages omitted.")
+    out.append("")
+    # family -> {suite -> newest version among that family's members}
+    fam_versions = {}
+    for suite in active:
+        for name, ver in suite_data[suite]["utils"].items():
+            if name.endswith("-dbgsym"):
+                continue
+            fam = util_family(name)
+            cur = fam_versions.setdefault(fam, {}).get(suite)
+            if cur is None or version_gt(ver, cur):
+                fam_versions[fam][suite] = ver
+    out.append("| Package | " + " | ".join(f"`{s}`" for s in active) + " |")
+    out.append("|:--------|" + "|".join(":-:" for _ in active) + "|")
+    for fam in sorted(fam_versions):
+        row = [f"| `{fam}` " if "(" not in fam else f"| {fam} "]
+        for suite in active:
+            v = fam_versions[fam].get(suite)
+            row.append(f"| {('`'+v+'`') if v else '—'} ")
+        out.append("".join(row) + "|")
+    out.append("")
+
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base-url", default=DEFAULT_BASE)
+    ap.add_argument("--suites", nargs="*",
+                    help=f"suites to include (default: {' '.join(DEFAULT_SUITES)})")
+    ap.add_argument("--all", action="store_true",
+                    help="include every suite present in the repository")
+    ap.add_argument("--arch", default="arm64")
+    ap.add_argument("--component", default="main")
+    ap.add_argument("--kernels", action="store_true",
+                    help="add a per-family kernel table flagging versions that lag the release")
+    ap.add_argument("--output", help="write Markdown here (default: stdout)")
+    args = ap.parse_args()
+
+    if args.suites:
+        suites = args.suites
+    elif args.all:
+        suites = discover_suites(args.base_url)
+    else:
+        suites = DEFAULT_SUITES
+    if not suites:
+        sys.exit("no suites found (network issue?)")
+
+    report = build_report(args.base_url, suites, args.component, args.arch,
+                          kernels=args.kernels)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/apt-repo-status.py
+++ b/tools/apt-repo-status.py
@@ -217,6 +217,28 @@ def build_report(base, suites, component, arch, kernels=False):
             if cur is None or version_gt(st["Version"], cur["Version"]):
                 merged[name] = st
 
+    def headers_status(image_name, image_ver):
+        """Every linux-image must ship a matching linux-headers at the same
+        version. Returns (kind, headers_version): ok / mismatch / missing."""
+        hname = image_name.replace("linux-image-", "linux-headers-", 1)
+        hst = merged.get(hname)
+        if hst is None:
+            return ("missing", None)
+        if hst["Version"] == image_ver:
+            return ("ok", hst["Version"])
+        return ("mismatch", hst["Version"])
+
+    header_issues = []  # (branch, family, image_ver, kind, headers_ver)
+    for name, st in merged.items():
+        if not name.startswith("linux-image-"):
+            continue
+        kind, hver = headers_status(name, st["Version"])
+        if kind != "ok":
+            parts = name.split("-")
+            branch = parts[2] if len(parts) > 2 else "?"
+            family = "-".join(parts[3:]) if len(parts) > 3 else "?"
+            header_issues.append((branch, family, st["Version"], kind, hver))
+
     # --- Core packages (single column — same across every suite)
     out.append("### Core package versions")
     out.append("")
@@ -253,6 +275,19 @@ def build_report(base, suites, component, arch, kernels=False):
             out.append(f"| {branch} | 0 | — | — |")
     out.append("")
 
+    # Integrity note: image and headers must share a version for every family.
+    if header_issues:
+        out.append(f"> ⚠️ **Header mismatch:** {len(header_issues)} kernel "
+                   f"{'family' if len(header_issues) == 1 else 'families'} have "
+                   f"`linux-headers` missing or at a different version than "
+                   f"`linux-image`"
+                   + (" — see the Kernel families table below." if kernels
+                      else " (run with `--kernels` for the list)."))
+        out.append("")
+    else:
+        out.append("> ✅ Every kernel family ships matching `linux-headers`.")
+        out.append("")
+
     # --- Per-family kernel drift (opt-in): every family, newest version, and
     #     whether it lags the current release. Answers "which kernels drift".
     if kernels:
@@ -272,14 +307,19 @@ def build_report(base, suites, component, arch, kernels=False):
                    f"The current release line is `{ref}`; families below it were not "
                    f"rebuilt for it.")
         out.append("")
-        out.append(f"**{n_behind} of {len(rows)} families behind `{ref}`.**")
+        out.append(f"**{n_behind} of {len(rows)} families behind `{ref}`.** "
+                   f"**{len(header_issues)} with header mismatches.**")
         out.append("")
-        out.append("| Branch | Family | Kernel | Armbian version | Status |")
-        out.append("|:-------|:-------|:-------|:----------------|:-------|")
+        out.append("| Branch | Family | Kernel | Armbian version | Headers | Status |")
+        out.append("|:-------|:-------|:-------|:----------------|:--------|:-------|")
         # behind families first (most useful), then by branch and family name
         for behind, branch, family, kver, ver in sorted(rows, key=lambda r: (not r[0], r[1], r[2])):
             status = f"⚠️ behind `{ref}`" if behind else "✅ current"
-            out.append(f"| {branch} | `{family}` | `{kver}` | `{ver}` | {status} |")
+            kind, hver = headers_status(f"linux-image-{branch}-{family}", ver)
+            headers = {"ok": "✅",
+                       "mismatch": f"⚠️ `{hver}`",
+                       "missing": "❌ missing"}[kind]
+            out.append(f"| {branch} | `{family}` | `{kver}` | `{ver}` | {headers} | {status} |")
         out.append("")
 
     # --- Third-party / utility packages (the "-utils" component), per suite,

--- a/tools/apt-repo-status.py
+++ b/tools/apt-repo-status.py
@@ -310,16 +310,16 @@ def build_report(base, suites, component, arch, kernels=False):
         out.append(f"**{n_behind} of {len(rows)} families behind `{ref}`.** "
                    f"**{len(header_issues)} with header mismatches.**")
         out.append("")
-        out.append("| Branch | Family | Kernel | Armbian version | Headers | Status |")
-        out.append("|:-------|:-------|:-------|:----------------|:--------|:-------|")
-        # behind families first (most useful), then by branch and family name
-        for behind, branch, family, kver, ver in sorted(rows, key=lambda r: (not r[0], r[1], r[2])):
+        out.append("| Family and branch | Kernel | Armbian version | Headers | Status |")
+        out.append("|:------------------|:-------|:----------------|:--------|:-------|")
+        # behind families first (most useful), then by the merged family-branch name
+        for behind, branch, family, kver, ver in sorted(rows, key=lambda r: (not r[0], f"{r[2]}-{r[1]}")):
             status = f"⚠️ behind `{ref}`" if behind else "✅ current"
             kind, hver = headers_status(f"linux-image-{branch}-{family}", ver)
             headers = {"ok": "✅",
                        "mismatch": f"⚠️ `{hver}`",
                        "missing": "❌ missing"}[kind]
-            out.append(f"| {branch} | `{family}` | `{kver}` | `{ver}` | {headers} | {status} |")
+            out.append(f"| `{family}-{branch}` | `{kver}` | `{ver}` | {headers} | {status} |")
         out.append("")
 
     # --- Third-party / utility packages (the "-utils" component), per suite,

--- a/tools/apt-repo-status.py
+++ b/tools/apt-repo-status.py
@@ -81,6 +81,20 @@ def version_max(versions):
     return best
 
 
+import functools
+
+
+def _vcmp(a, b):
+    if version_gt(a, b):
+        return 1
+    if version_gt(b, a):
+        return -1
+    return 0
+
+
+version_key = functools.cmp_to_key(_vcmp)
+
+
 # --- Repository access ---------------------------------------------------------
 def discover_suites(base):
     try:
@@ -144,14 +158,25 @@ def build_report(base, suites, component, arch, kernels=False):
     out.append("")
 
     def latest_map(stanzas):
+        """name -> the whole stanza with the newest Version."""
         latest = {}
         for st in stanzas or []:
             name, ver = st.get("Package"), st.get("Version")
             if not name or not ver:
                 continue
-            if name not in latest or version_gt(ver, latest[name]):
-                latest[name] = ver
+            cur = latest.get(name)
+            if cur is None or version_gt(ver, cur["Version"]):
+                latest[name] = st
         return latest
+
+    def kernel_version(st):
+        """Linux kernel version for a linux-image stanza."""
+        kv = st.get("Armbian-Kernel-Version")
+        if kv:
+            return kv
+        src = st.get("Source", "")
+        m = re.match(r"linux-(\S+)", src)
+        return m.group(1) if m else "?"
 
     suite_data = {}
     for suite in suites:
@@ -176,7 +201,7 @@ def build_report(base, suites, component, arch, kernels=False):
             continue
         rel = d["release"]
         updated = rel.get("Date", "—")[:16]
-        newest = version_max(d["latest"].values()) or "—"
+        newest = version_max([st["Version"] for st in d["latest"].values()]) or "—"
         out.append(f"| `{suite}` | {rel.get('Codename', suite)} | {updated} "
                    f"| {d['count']} | `{newest}` |")
     out.append("")
@@ -184,12 +209,13 @@ def build_report(base, suites, component, arch, kernels=False):
     active = [s for s in suites if s in suite_data]
 
     # Armbian's `main` content is identical across suites, so merge it into a
-    # single view (newest version seen for each package across all suites).
+    # single view (stanza with the newest Version for each package).
     merged = {}
     for suite in active:
-        for name, ver in suite_data[suite]["latest"].items():
-            if name not in merged or version_gt(ver, merged[name]):
-                merged[name] = ver
+        for name, st in suite_data[suite]["latest"].items():
+            cur = merged.get(name)
+            if cur is None or version_gt(st["Version"], cur["Version"]):
+                merged[name] = st
 
     # --- Core packages (single column — same across every suite)
     out.append("### Core package versions")
@@ -199,7 +225,8 @@ def build_report(base, suites, component, arch, kernels=False):
     out.append("| Package | Version |")
     out.append("|:--------|:--------|")
     for pkg in CORE_PACKAGES:
-        v = merged.get(pkg)
+        st = merged.get(pkg)
+        v = st["Version"] if st else None
         out.append(f"| `{pkg}` | {('`'+v+'`') if v else '—'} |")
     out.append("")
 
@@ -209,45 +236,50 @@ def build_report(base, suites, component, arch, kernels=False):
     out.append("Distinct kernel families and the newest Armbian version published "
                "per branch (from `linux-image-<branch>-*`).")
     out.append("")
-    out.append("| Branch | Families | Latest version |")
-    out.append("|:-------|--------:|:--------------|")
+    out.append("| Branch | Families | Latest kernel | Armbian version |")
+    out.append("|:-------|--------:|:-------------|:---------------|")
     for branch in KERNEL_BRANCHES:
-        fams, vers = set(), []
-        for name, ver in merged.items():
+        fams, stanzas = set(), []
+        for name, st in merged.items():
             if name.startswith(f"linux-image-{branch}-"):
                 fams.add(name)
-                vers.append(ver)
+                stanzas.append(st)
         if fams:
-            out.append(f"| {branch} | {len(fams)} | `{version_max(vers)}` |")
+            newest = max(stanzas, key=lambda s: version_key(s["Version"]))
+            kvers = sorted({kernel_version(s) for s in stanzas}, key=version_key)
+            krange = kvers[-1] if len(kvers) == 1 else f"{kvers[0]} – {kvers[-1]}"
+            out.append(f"| {branch} | {len(fams)} | `{krange}` | `{newest['Version']}` |")
         else:
-            out.append(f"| {branch} | 0 | — |")
+            out.append(f"| {branch} | 0 | — | — |")
     out.append("")
 
     # --- Per-family kernel drift (opt-in): every family, newest version, and
     #     whether it lags the current release. Answers "which kernels drift".
     if kernels:
-        fam_latest = {n: v for n, v in merged.items() if n.startswith("linux-image-")}
-        ref = version_max(fam_latest.values())
+        fam_st = {n: st for n, st in merged.items() if n.startswith("linux-image-")}
+        ref = version_max([st["Version"] for st in fam_st.values()])
         rows = []
-        for name, ver in fam_latest.items():
+        for name, st in fam_st.items():
             parts = name.split("-")           # linux-image-<branch>-<family...>
             branch = parts[2] if len(parts) > 2 else "?"
             family = "-".join(parts[3:]) if len(parts) > 3 else "?"
-            rows.append((version_gt(ref, ver), branch, family, ver))
+            ver = st["Version"]
+            rows.append((version_gt(ref, ver), branch, family, kernel_version(st), ver))
         n_behind = sum(1 for r in rows if r[0])
         out.append("### Kernel families")
         out.append("")
-        out.append(f"Newest version published per kernel family. The current release "
-                   f"line is `{ref}`; families below it were not rebuilt for it.")
+        out.append(f"Newest kernel published per family, with its Linux kernel version. "
+                   f"The current release line is `{ref}`; families below it were not "
+                   f"rebuilt for it.")
         out.append("")
         out.append(f"**{n_behind} of {len(rows)} families behind `{ref}`.**")
         out.append("")
-        out.append("| Branch | Family | Version | Status |")
-        out.append("|:-------|:-------|:--------|:-------|")
+        out.append("| Branch | Family | Kernel | Armbian version | Status |")
+        out.append("|:-------|:-------|:-------|:----------------|:-------|")
         # behind families first (most useful), then by branch and family name
-        for behind, branch, family, ver in sorted(rows, key=lambda r: (not r[0], r[1], r[2])):
+        for behind, branch, family, kver, ver in sorted(rows, key=lambda r: (not r[0], r[1], r[2])):
             status = f"⚠️ behind `{ref}`" if behind else "✅ current"
-            out.append(f"| {branch} | `{family}` | `{ver}` | {status} |")
+            out.append(f"| {branch} | `{family}` | `{kver}` | `{ver}` | {status} |")
         out.append("")
 
     # --- Third-party / utility packages (the "-utils" component), per suite,
@@ -261,9 +293,10 @@ def build_report(base, suites, component, arch, kernels=False):
     # family -> {suite -> newest version among that family's members}
     fam_versions = {}
     for suite in active:
-        for name, ver in suite_data[suite]["utils"].items():
+        for name, st in suite_data[suite]["utils"].items():
             if name.endswith("-dbgsym"):
                 continue
+            ver = st["Version"]
             fam = util_family(name)
             cur = fam_versions.setdefault(fam, {}).get(suite)
             if cur is None or version_gt(ver, cur):


### PR DESCRIPTION
Adds a tool that reports the state of the **apt.armbian.com** repository and surfaces it **in the job summary at PR stage**.

### `tools/apt-repo-status.py`
Dependency-free, runs locally, prints Markdown (or `--output FILE`):

- **Suites** — codename, last updated, package count, current Armbian version.
- **Core package versions** — `armbian-firmware`, `-full`, `-zsh`, `-plymouth-theme` (identical across suites, so shown once).
- **Kernel branches** — family count + newest version per current/edge/legacy/vendor.
- **Third-party & utility packages** — imported upstream tools per suite, with split families (JDK, OpenZFS, …) folded and `-dbgsym` dropped.
- **`--kernels`** — per-family table flagging which kernel families **lag the current release**, drifters first. (Right now: **25 of 82 families behind `26.8.3`** — e.g. `sm8250/arm64` and `legacy/rockpis` stuck at `24.2.1`.)

Options: `--suites …` / `--all`, `--arch`, `--component`, `--kernels`, `--output`.

### `.github/workflows/apt-repo-status.yml`
Runs the report with `--kernels` and writes it to `$GITHUB_STEP_SUMMARY`, so the status (and kernel drift) shows up **at PR stage** — plus daily and on manual dispatch. Installs `python3-apt` for accurate Debian version comparison and uploads the Markdown as an artifact.

To keep it from firing on unrelated docs PRs, the `pull_request` trigger is scoped to the script/workflow paths; `workflow_dispatch` runs it on demand against the live repo.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1039"><kbd><br> Open WWW preview <br></kbd></a>