### PR TITLE
docs: move "run a mirror" instructions back to Contribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ site/
 venv/
 .venv/
 *.pdf
-.DS_Store
+.DS_Store__pycache__/

--- a/docs/contribute/run-a-mirror.md
+++ b/docs/contribute/run-a-mirror.md
@@ -1,0 +1,30 @@
+---
+seo_title: "Run an Armbian mirror: rsync sync & registration"
+description: "How to contribute an Armbian mirror: set up an HTTPS host, sync the images and packages over rsync, and register the server with the redirector network."
+---
+# Run a mirror
+
+Armbian's downloads are served by a network of community mirrors behind a
+redirector. If you can host one, here is how. You can see the
+[current mirrors and how the system works](/status/mirrors/) on the status page.
+
+### 1. Set up an HTTP(S) host
+
+The mirror must be reachable over HTTPS (plain HTTP is also accepted). Point a hostname at it before you start syncing.
+
+### 2. Sync with `rsync`
+
+Pull the content you want to serve from one of the official modules, and run it from cron every **2-4 hours**:
+
+| Content | Command | Required space |
+|---------|---------|---------------:|
+| Current images | `rsync -av rsync://rsync.armbian.com/dl` | 556G |
+| Packages | `rsync -av rsync://rsync.armbian.com/apt` | 84G |
+| Archived images | `rsync -av rsync://rsync.armbian.com/archive` | 1.9T |
+| Very old images | `rsync -av rsync://rsync.armbian.com/oldarchive` | 5.4T |
+
+### 3. Tell us about it
+
+Once the server is running, reach out through the [contact form](https://www.armbian.com/contact/) so we can add it to the official redirector.
+
+Thanks for helping keep Armbian's downloads fast and reliable worldwide.

--- a/docs/status/mirrors.md
+++ b/docs/status/mirrors.md
@@ -1,11 +1,11 @@
 ---
-seo_title: "Armbian mirror system & how to add a mirror"
-description: "How the Armbian mirror system works: a redirector routes downloads to the fastest nearby mirror, plus mirror specs and steps to contribute a new server."
+seo_title: "Armbian mirrors: the mirror network & redirector"
+description: "The Armbian mirror network: a redirector routes each download to the fastest nearby mirror. See every active mirror and how the system works."
 comments: true
 ---
 # How the Armbian mirror system works
 
-The [Armbian mirror system](https://github.com/armbian/armbian-router) distributes files efficiently, routing each user to the best available server by geographic proximity and server health. Pick a nearby mirror from the list below, or read on for how the system works and how to contribute one.
+The [Armbian mirror system](https://github.com/armbian/armbian-router) distributes files efficiently, routing each user to the best available server by geographic proximity and server health. Pick a nearby mirror from the list below, or read on for how the system works. Want to host a mirror? See [**Run a mirror**](/contribute/run-a-mirror/).
 
 <!-- mirrors:start -->
 ## Current Mirrors
@@ -70,27 +70,6 @@ The [Armbian mirror system](https://github.com/armbian/armbian-router) distribut
 
 The result is **load balancing** across many servers, **faster downloads** from a nearby mirror, and **redundancy** — if a mirror is unavailable, the redirector automatically routes around it.
 
-## Contribute a mirror
+## Host a mirror
 
-If you can host a mirror for the project, here is how.
-
-### 1. Set up an HTTP(S) host
-
-The mirror must be reachable over HTTPS (plain HTTP is also accepted). Point a hostname at it before you start syncing.
-
-### 2. Sync with `rsync`
-
-Pull the content you want to serve from one of the official modules, and run it from cron every **2-4 hours**:
-
-| Content | Command | Required space |
-|---------|---------|---------------:|
-| Current images | `rsync -av rsync://rsync.armbian.com/dl` | 556G |
-| Packages | `rsync -av rsync://rsync.armbian.com/apt` | 84G |
-| Archived images | `rsync -av rsync://rsync.armbian.com/archive` | 1.9T |
-| Very old images | `rsync -av rsync://rsync.armbian.com/oldarchive` | 5.4T |
-
-### 3. Tell us about it
-
-Once the server is running, reach out through the [contact form](https://www.armbian.com/contact/) so we can add it to the official redirector.
-
-Thanks for helping keep Armbian's downloads fast and reliable worldwide.
+Want to help serve Armbian's downloads? See [**Run a mirror**](/contribute/run-a-mirror/) for the requirements, the `rsync` sync commands and how to register your server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -354,6 +354,7 @@ nav:
         - 'Get involved' : 'contribute/index.md'
         - 'Ways to contribute' :
             - 'armbian-config apps' : 'contribute/armbian-config.md'
+            - 'Run a mirror' : 'contribute/run-a-mirror.md'
             - 'Datacenter access' : 'contribute/datacenter.md'
         - 'Maintainers & board rules' :
             - 'Board Support Rules' : 'contribute/board-support-rules.md'


### PR DESCRIPTION
Splits the mirrors page so each half sits where it belongs:

- **STATUS** (`status/mirrors.md`) keeps the **mirror list** and *how the system works* — the live/reference content. It now ends with a short **Host a mirror** pointer, and its intro/SEO drop the "how to contribute" framing.
- **CONTRIBUTE** gets a new **`contribute/run-a-mirror.md`** (Ways to contribute) with the how-to: set up an HTTPS host, the `rsync` sync commands + required space, and registration.

The mirror-refresh `<!-- mirrors:start/end -->` markers are untouched, so `pull-mirrors-from-db.yml` keeps updating the list unaffected. No new redirects needed (new slug); validated that nav resolves and nothing links the old anchor.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1042"><kbd><br> Open WWW preview <br></kbd></a>