### PR TITLE
feat(status): Build machinery page (runner fleet from NetBox + GitHub)

### DIFF
--- a/.github/workflows/build-machinery-status.yml
+++ b/.github/workflows/build-machinery-status.yml
@@ -1,0 +1,82 @@
+name: "Build machinery status"
+
+# Reports the Armbian build machinery — the self-hosted runner fleet: each
+# runner's CPU-thread capacity, memory and location (from NetBox), plus the
+# org's GitHub runners grouped by label. Because it needs secrets it runs on a
+# schedule / manual dispatch (not on PRs); it splices the report into
+# docs/status/build-machinery.md and opens a PR.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 6 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  status:
+    name: "Build machinery"
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'armbian' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate build machinery report
+        env:
+          NETBOX_TOKEN: ${{ secrets.NETBOX_TOKEN }}
+          NETBOX_API: ${{ secrets.NETBOX_API }}
+          GH_RUNNERS_TOKEN: ${{ secrets.RUNNERS }}
+        run: |
+          python3 tools/build-machinery-status.py > report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Markdown report
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-machinery-status
+          path: report.md
+          if-no-files-found: error
+
+      - name: Splice report into the docs page
+        run: |
+          PAGE="docs/status/build-machinery.md"
+          {
+            echo '<!-- build-machinery:start -->'
+            cat report.md
+            echo '<!-- build-machinery:end -->'
+          } > block.md
+          # Fail closed: require exactly one ordered marker pair before writing.
+          starts=$(grep -c '<!-- build-machinery:start -->' "$PAGE" || true)
+          ends=$(grep -c '<!-- build-machinery:end -->' "$PAGE" || true)
+          sline=$(grep -n '<!-- build-machinery:start -->' "$PAGE" | head -1 | cut -d: -f1)
+          eline=$(grep -n '<!-- build-machinery:end -->' "$PAGE" | head -1 | cut -d: -f1)
+          if [ "$starts" -ne 1 ] || [ "$ends" -ne 1 ] || [ "${sline:-0}" -ge "${eline:-0}" ]; then
+            echo "::error::build-machinery markers invalid in $PAGE (start=$starts end=$ends order=$sline/$eline)"
+            exit 1
+          fi
+          awk -v bf=block.md '
+            BEGIN { while ((getline l < bf) > 0) B = B l ORS }
+            /<!-- build-machinery:start -->/ { printf "%s", B; skip=1; next }
+            /<!-- build-machinery:end -->/   { skip=0; next }
+            !skip { print }
+          ' "$PAGE" > tmp.md && mv tmp.md "$PAGE"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: '`Automatic` build machinery status update'
+          signoff: false
+          branch: auto-update-build-machinery
+          delete-branch: true
+          title: '`Automatic` build machinery status update'
+          body: |
+            Regenerated `docs/status/build-machinery.md` — the runner fleet
+            (CPU threads, memory, location) from NetBox and the org runners by
+            label from GitHub.
+          labels: |
+            Needs review
+          draft: false

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -13,8 +13,6 @@ runner processes each server hosts (from the
 <!-- build-machinery:start -->
 ## Build servers
 
-_Build servers from [NetBox](https://netbox.armbian.com/), tagged `github-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
-
 **17** servers · **686** threads · **1932** GB RAM · **284** runners (**167** online).
 
 | Server | Location | Threads | RAM | Runners | Status |

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,29 +15,29 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **268** runners (**104** online).
+**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **268** runners (**103** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
-| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 40 | online |
-| `ampere-1` | GitHub | 128 | 500 GB | 64 | ⚠️ offline |
-| `kspace` | Imola | 128 | 264 GB | 32 | online |
+| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 40 | active |
+| `ampere-1` | GitHub | 128 | 500 GB | 64 | active |
+| `kspace` | Imola | 128 | 264 GB | 32 | active |
 | `github` | GitHub | 40 | 137 GB | 20 | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | ⚠️ offline |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | active |
 | `game` | Imola | 32 | 132 GB | 15 | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | ⚠️ offline |
-| `stpete` | JetHome | 24 | 64 GB | 6 | ⚠️ offline |
-| `geekom` | Mirrors | 20 | 62 GB | 8 | ⚠️ offline |
-| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | online |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
+| `stpete` | JetHome | 24 | 64 GB | 6 | active |
+| `geekom` | Mirrors | 20 | 62 GB | 8 | active |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
 | `mind` | GitHub | 16 | 16 GB | 2 | ⚠️ offline |
 | `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
 | `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
-| `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | online |
+| `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
 | `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
 | `nanopim6` | GitHub | 8 | 32 GB | 6 | ⚠️ offline |
 | `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | 0 | ⚠️ offline |
 | `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | 0 | ⚠️ offline |
 | `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | 2 | ⚠️ offline |
+| `big-arm` | LaneCloud | 4 | 24 GB | 2 | active |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,29 +15,27 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **268** runners (**103** online).
+**18** servers — **15** active, **3** offline · **706** CPU threads (**686** active) · **2045** GB RAM · **260** runners (**104** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
-| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 40 | active |
-| `ampere-1` | GitHub | 128 | 500 GB | 64 | active |
-| `kspace` | Imola | 128 | 264 GB | 32 | active |
-| `github` | GitHub | 40 | 137 GB | 20 | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | active |
-| `game` | Imola | 32 | 132 GB | 15 | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
-| `stpete` | JetHome | 24 | 64 GB | 6 | active |
-| `geekom` | Mirrors | 20 | 62 GB | 8 | active |
-| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
-| `mind` | GitHub | 16 | 16 GB | 2 | ⚠️ offline |
-| `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
-| `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
+| `insa-trixie` | Hetzner Germany | 176 | 384 GB | 40 | active |
+| `ampere-1` | Armbian Datacenter | 128 | 512 GB | 64 | active |
+| `kspace` | Imola | 128 | 270 GB | 32 | active |
+| `github` | GitHub | 40 | 140 GB | 20 | active |
+| `3950x` | Armbian Datacenter | 32 | 128 GB | 8 | active |
+| `game` | Imola | 32 | 135 GB | 15 | active |
+| `rack-ryzen` | Armbian Datacenter | 32 | 128 GB | 15 | active |
+| `stpete` | JetHome | 24 | 66 GB | 6 | active |
+| `geekom` | Mirrors | 20 | 64 GB | 8 | active |
+| `cats` | Auroradev Las Vegas | 16 | 33 GB | 6 | active |
+| `oregonalfa` | Oregon UNI | 16 | 32 GB | 6 | active |
+| `oregonbeta` | Oregon UNI | 16 | 32 GB | 6 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
 | `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
-| `nanopim6` | GitHub | 8 | 32 GB | 6 | ⚠️ offline |
 | `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | 0 | ⚠️ offline |
 | `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | 0 | ⚠️ offline |
-| `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | 2 | active |
+| `werner` | Hetzner Germany | 8 | 32 GB | 4 | active |
+| `big-arm` | LaneCloud | 4 | 25 GB | 2 | ⚠️ offline |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -10,6 +10,14 @@ location (from [NetBox](https://netbox.armbian.com/)), and how many GitHub
 runner processes each server hosts (from the
 [GitHub organisation](https://github.com/armbian)).
 
+!!! note "Powered on demand"
+
+    Not all of this capacity runs around the clock. A good part of the fleet
+    sits on **standby and only powers up when there is build demand**, then
+    spins back down once the queue is clear — keeping idle energy use and cost
+    low as part of a greener build infrastructure. A server showing few or no
+    online runners may simply be asleep, not broken.
+
 <!-- build-machinery:start -->
 ## Build servers
 

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -1,42 +1,43 @@
 ---
 title: Build machinery
-seo_title: "Armbian build machinery: self-hosted runner fleet"
-description: "The Armbian build machinery — self-hosted GitHub Actions runners, their CPU-thread capacity, memory and location — from NetBox and the GitHub organisation."
+seo_title: "Armbian build machinery: build server fleet"
+description: "The Armbian build machinery — the build servers that compile Armbian: CPU-thread capacity, memory and location from NetBox, and the GitHub runner processes each hosts."
 ---
 # Build machinery
 
-The self-hosted runners that build Armbian — their CPU-thread capacity, memory
-and location (from [NetBox](https://netbox.armbian.com/)), and how they are
-registered by label on the [GitHub organisation](https://github.com/armbian).
+The build servers that compile Armbian — their CPU-thread capacity, memory and
+location (from [NetBox](https://netbox.armbian.com/)), and how many GitHub
+runner processes each server hosts (from the
+[GitHub organisation](https://github.com/armbian)).
 
 <!-- build-machinery:start -->
-## Runner fleet
+## Build servers
 
-_Self-hosted runners from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`._
+_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (matched by its label)._
 
-**20** runners — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM.
+**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM.
 
-| Runner | Location | Threads | RAM | Status |
-|:-------|:---------|--------:|----:|:------:|
-| `insanisfiction.armbian.de` | Hetzner Germany | 176 | 375 GB | active |
-| `ampere-1` | GitHub | 128 | 500 GB | active |
-| `kspace` | Imola | 128 | 264 GB | active |
-| `github.com` | GitHub | 40 | 137 GB | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | active |
-| `game.imola.armbian.com` | Imola | 32 | 132 GB | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | active |
-| `stpete-runner.armbian.com` | JetHome | 24 | 64 GB | active |
-| `geekom` | Mirrors | 20 | 62 GB | active |
-| `cats` | Auroradev Las Vegas | 16 | 32 GB | active |
-| `mind` | GitHub | 16 | 16 GB | ⚠️ offline |
-| `oregon-uni-1.armbian.com` | Oregon UNI | 16 | 31 GB | active |
-| `oregon-uni-2.armbian.com` | Oregon UNI | 16 | 31 GB | active |
-| `repo.armbian.com` | Netcup Germany | 10 | 16 GB | active |
-| `mt7925e` | Kspace Estonia | 8 | 16 GB | active |
-| `nanopim6` | GitHub | 8 | 32 GB | ⚠️ offline |
-| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | ⚠️ offline |
-| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | ⚠️ offline |
-| `werner` | Hetzner Germany | 8 | 31 GB | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | active |
+| Server | Location | Threads | RAM | Runners | Status |
+|:-------|:---------|--------:|----:|--------:|:------:|
+| `insanisfiction.armbian.de` | Hetzner Germany | 176 | 375 GB | — | active |
+| `ampere-1` | GitHub | 128 | 500 GB | — | active |
+| `kspace` | Imola | 128 | 264 GB | — | active |
+| `github.com` | GitHub | 40 | 137 GB | — | active |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | — | active |
+| `game.imola.armbian.com` | Imola | 32 | 132 GB | — | active |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | — | active |
+| `stpete-runner.armbian.com` | JetHome | 24 | 64 GB | — | active |
+| `geekom` | Mirrors | 20 | 62 GB | — | active |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | — | active |
+| `mind` | GitHub | 16 | 16 GB | — | ⚠️ offline |
+| `oregon-uni-1.armbian.com` | Oregon UNI | 16 | 31 GB | — | active |
+| `oregon-uni-2.armbian.com` | Oregon UNI | 16 | 31 GB | — | active |
+| `repo.armbian.com` | Netcup Germany | 10 | 16 GB | — | active |
+| `mt7925e` | Kspace Estonia | 8 | 16 GB | — | active |
+| `nanopim6` | GitHub | 8 | 32 GB | — | ⚠️ offline |
+| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | — | ⚠️ offline |
+| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | — | ⚠️ offline |
+| `werner` | Hetzner Germany | 8 | 31 GB | — | active |
+| `big-arm` | LaneCloud | 4 | 24 GB | — | active |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -13,9 +13,9 @@ runner processes each server hosts (from the
 <!-- build-machinery:start -->
 ## Build servers
 
-_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
+_Build servers from [NetBox](https://netbox.armbian.com/), tagged `github-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**12** servers · **614** threads · **1683** GB RAM · **233** runners (**108** online).
+**20** servers (**2** offline) · **734** threads (**702** active) · **1987** GB RAM · **288** runners (**167** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
@@ -26,10 +26,18 @@ _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runne
 | `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
 | `stpete` | JetHome | 24 | 64 GB | 6 | active |
 | `geekom` | Armbian Datacenter | 20 | 62 GB | 8 | active |
+| `vps8000-1` | Netcup Germany | 18 | 62 GB | 9 | active |
+| `vps8000-2` | Netcup Germany | 18 | 62 GB | 14 | active |
 | `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
-| `oregonalfa` | Oregon UNI | 16 | 32 GB | 6 | active |
-| `oregonbeta` | Oregon UNI | 16 | 32 GB | 6 | active |
+| `lca-armbian-runner-big-1` | LaneCloud | 16 | 16 GB | 0 | ⚠️ offline |
+| `lca-armbian-runner-big-2` | LaneCloud | 16 | 16 GB | 0 | ⚠️ offline |
+| `oregon-1` | Oregon UNI | 16 | 32 GB | 8 | active |
+| `oregon-2` | Oregon UNI | 16 | 32 GB | 8 | active |
+| `hristov` | Aleksandr Hristov | 16 | 23 GB | 4 | active |
+| `stmir` | JetHome | 16 | 94 GB | 12 | active |
+| `vps3000-1` | Netcup Germany | 12 | 23 GB | 8 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
 | `werner-trixie` | Hetzner Germany | 8 | 31 GB | 4 | active |
+| `xogium-ryzen` | Xogium | 8 | 8 GB | 4 | active |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -13,31 +13,31 @@ runner processes each server hosts (from the
 <!-- build-machinery:start -->
 ## Build servers
 
-_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (matched by its label), falling back to the value recorded in NetBox when GitHub can't be queried._
+_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **235** runners.
+**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **268** runners (**104** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
-| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 50 | active |
-| `ampere-1` | GitHub | 128 | 500 GB | 41 | active |
-| `kspace` | Imola | 128 | 264 GB | 24 | active |
+| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 40 | online |
+| `ampere-1` | GitHub | 128 | 500 GB | 64 | ⚠️ offline |
+| `kspace` | Imola | 128 | 264 GB | 32 | online |
 | `github` | GitHub | 40 | 137 GB | 20 | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | active |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | ⚠️ offline |
 | `game` | Imola | 32 | 132 GB | 15 | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
-| `stpete` | JetHome | 24 | 64 GB | 8 | active |
-| `geekom` | Mirrors | 20 | 62 GB | 4 | active |
-| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | ⚠️ offline |
+| `stpete` | JetHome | 24 | 64 GB | 6 | ⚠️ offline |
+| `geekom` | Mirrors | 20 | 62 GB | 8 | ⚠️ offline |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | online |
 | `mind` | GitHub | 16 | 16 GB | 2 | ⚠️ offline |
 | `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
 | `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
-| `repoassembly` | Netcup Germany | 10 | 16 GB | 16 | active |
+| `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | online |
 | `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
 | `nanopim6` | GitHub | 8 | 32 GB | 6 | ⚠️ offline |
 | `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | 0 | ⚠️ offline |
 | `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | 0 | ⚠️ offline |
 | `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | 2 | active |
+| `big-arm` | LaneCloud | 4 | 24 GB | 2 | ⚠️ offline |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,7 +15,7 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**12** servers — **12** active, **0** offline · **614** CPU threads (**614** active) · **1683** GB RAM · **233** runners (**104** online).
+**12** servers · **614** threads · **1683** GB RAM · **233** runners (**108** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
@@ -30,6 +30,6 @@ _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runne
 | `oregonalfa` | Oregon UNI | 16 | 32 GB | 6 | active |
 | `oregonbeta` | Oregon UNI | 16 | 32 GB | 6 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
-| `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
+| `werner-trixie` | Hetzner Germany | 8 | 31 GB | 4 | active |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -13,31 +13,31 @@ runner processes each server hosts (from the
 <!-- build-machinery:start -->
 ## Build servers
 
-_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (matched by its label)._
+_Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (matched by its label), falling back to the value recorded in NetBox when GitHub can't be queried._
 
 **20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM.
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
-| `insa-trixie` | Hetzner Germany | 176 | 375 GB | — | active |
-| `ampere-1` | GitHub | 128 | 500 GB | — | active |
-| `kspace` | Imola | 128 | 264 GB | — | active |
-| `github` | GitHub | 40 | 137 GB | — | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | — | active |
-| `game` | Imola | 32 | 132 GB | — | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | — | active |
-| `stpete` | JetHome | 24 | 64 GB | — | active |
-| `geekom` | Mirrors | 20 | 62 GB | — | active |
-| `cats` | Auroradev Las Vegas | 16 | 32 GB | — | active |
-| `mind` | GitHub | 16 | 16 GB | — | ⚠️ offline |
-| `oregonalfa` | Oregon UNI | 16 | 31 GB | — | active |
-| `oregonbeta` | Oregon UNI | 16 | 31 GB | — | active |
-| `repoassembly` | Netcup Germany | 10 | 16 GB | — | active |
-| `mt7925e` | Kspace Estonia | 8 | 16 GB | — | active |
-| `nanopim6` | GitHub | 8 | 32 GB | — | ⚠️ offline |
-| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | — | ⚠️ offline |
-| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | — | ⚠️ offline |
-| `werner` | Hetzner Germany | 8 | 31 GB | — | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | — | active |
+| `insa-trixie` | Hetzner Germany | 176 | 375 GB | 50 | active |
+| `ampere-1` | GitHub | 128 | 500 GB | 41 | active |
+| `kspace` | Imola | 128 | 264 GB | 24 | active |
+| `github` | GitHub | 40 | 137 GB | 20 | active |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | active |
+| `game` | Imola | 32 | 132 GB | 15 | active |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
+| `stpete` | JetHome | 24 | 64 GB | 8 | active |
+| `geekom` | Mirrors | 20 | 62 GB | 4 | active |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
+| `mind` | GitHub | 16 | 16 GB | 2 | ⚠️ offline |
+| `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
+| `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
+| `repoassembly` | Netcup Germany | 10 | 16 GB | 16 | active |
+| `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
+| `nanopim6` | GitHub | 8 | 32 GB | 6 | ⚠️ offline |
+| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | 0 | ⚠️ offline |
+| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | 0 | ⚠️ offline |
+| `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
+| `big-arm` | LaneCloud | 4 | 24 GB | 2 | active |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -19,20 +19,20 @@ _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runne
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
-| `insanisfiction.armbian.de` | Hetzner Germany | 176 | 375 GB | — | active |
+| `insa-trixie` | Hetzner Germany | 176 | 375 GB | — | active |
 | `ampere-1` | GitHub | 128 | 500 GB | — | active |
 | `kspace` | Imola | 128 | 264 GB | — | active |
-| `github.com` | GitHub | 40 | 137 GB | — | active |
+| `github` | GitHub | 40 | 137 GB | — | active |
 | `3950x` | Armbian Datacenter | 32 | 125 GB | — | active |
-| `game.imola.armbian.com` | Imola | 32 | 132 GB | — | active |
+| `game` | Imola | 32 | 132 GB | — | active |
 | `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | — | active |
-| `stpete-runner.armbian.com` | JetHome | 24 | 64 GB | — | active |
+| `stpete` | JetHome | 24 | 64 GB | — | active |
 | `geekom` | Mirrors | 20 | 62 GB | — | active |
 | `cats` | Auroradev Las Vegas | 16 | 32 GB | — | active |
 | `mind` | GitHub | 16 | 16 GB | — | ⚠️ offline |
-| `oregon-uni-1.armbian.com` | Oregon UNI | 16 | 31 GB | — | active |
-| `oregon-uni-2.armbian.com` | Oregon UNI | 16 | 31 GB | — | active |
-| `repo.armbian.com` | Netcup Germany | 10 | 16 GB | — | active |
+| `oregonalfa` | Oregon UNI | 16 | 31 GB | — | active |
+| `oregonbeta` | Oregon UNI | 16 | 31 GB | — | active |
+| `repoassembly` | Netcup Germany | 10 | 16 GB | — | active |
 | `mt7925e` | Kspace Estonia | 8 | 16 GB | — | active |
 | `nanopim6` | GitHub | 8 | 32 GB | — | ⚠️ offline |
 | `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | — | ⚠️ offline |

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,7 +15,7 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), tagged `github-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**20** servers (**2** offline) · **734** threads (**702** active) · **1987** GB RAM · **288** runners (**167** online).
+**17** servers · **686** threads · **1932** GB RAM · **284** runners (**167** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
@@ -29,11 +29,8 @@ _Build servers from [NetBox](https://netbox.armbian.com/), tagged `github-runner
 | `vps8000-1` | Netcup Germany | 18 | 62 GB | 9 | active |
 | `vps8000-2` | Netcup Germany | 18 | 62 GB | 14 | active |
 | `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
-| `lca-armbian-runner-big-1` | LaneCloud | 16 | 16 GB | 0 | ⚠️ offline |
-| `lca-armbian-runner-big-2` | LaneCloud | 16 | 16 GB | 0 | ⚠️ offline |
 | `oregon-1` | Oregon UNI | 16 | 32 GB | 8 | active |
 | `oregon-2` | Oregon UNI | 16 | 32 GB | 8 | active |
-| `hristov` | Aleksandr Hristov | 16 | 23 GB | 4 | active |
 | `stmir` | JetHome | 16 | 94 GB | 12 | active |
 | `vps3000-1` | Netcup Germany | 12 | 23 GB | 8 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,27 +15,24 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**18** servers — **15** active, **3** offline · **706** CPU threads (**686** active) · **2045** GB RAM · **260** runners (**104** online).
+**15** servers — **13** active, **2** offline · **658** CPU threads (**622** active) · **1846** GB RAM · **245** runners (**104** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
 | `insa-trixie` | Hetzner Germany | 176 | 384 GB | 40 | active |
 | `ampere-1` | Armbian Datacenter | 128 | 512 GB | 64 | active |
-| `kspace` | Imola | 128 | 270 GB | 32 | active |
-| `github` | GitHub | 40 | 140 GB | 20 | active |
-| `3950x` | Armbian Datacenter | 32 | 128 GB | 8 | active |
-| `game` | Imola | 32 | 135 GB | 15 | active |
-| `rack-ryzen` | Armbian Datacenter | 32 | 128 GB | 15 | active |
-| `stpete` | JetHome | 24 | 66 GB | 6 | active |
-| `geekom` | Mirrors | 20 | 64 GB | 8 | active |
-| `cats` | Auroradev Las Vegas | 16 | 33 GB | 6 | active |
-| `oregonalfa` | Oregon UNI | 16 | 32 GB | 6 | active |
-| `oregonbeta` | Oregon UNI | 16 | 32 GB | 6 | active |
+| `kspace` | Kspace Estonia | 128 | 256 GB | 32 | active |
+| `github` | GitHub | 40 | 137 GB | 20 | active |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | ⚠️ decommissioning |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
+| `stpete` | JetHome | 24 | 64 GB | 6 | active |
+| `geekom` | Mirrors | 20 | 62 GB | 8 | active |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
+| `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
+| `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
 | `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
-| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | 0 | ⚠️ offline |
-| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | 0 | ⚠️ offline |
-| `werner` | Hetzner Germany | 8 | 32 GB | 4 | active |
-| `big-arm` | LaneCloud | 4 | 25 GB | 2 | ⚠️ offline |
+| `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
+| `big-arm` | LaneCloud | 4 | 24 GB | 2 | ⚠️ offline |
 
 <!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -1,0 +1,42 @@
+---
+title: Build machinery
+seo_title: "Armbian build machinery: self-hosted runner fleet"
+description: "The Armbian build machinery — self-hosted GitHub Actions runners, their CPU-thread capacity, memory and location — from NetBox and the GitHub organisation."
+---
+# Build machinery
+
+The self-hosted runners that build Armbian — their CPU-thread capacity, memory
+and location (from [NetBox](https://netbox.armbian.com/)), and how they are
+registered by label on the [GitHub organisation](https://github.com/armbian).
+
+<!-- build-machinery:start -->
+## Runner fleet
+
+_Self-hosted runners from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`._
+
+**20** runners — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM.
+
+| Runner | Location | Threads | RAM | Status |
+|:-------|:---------|--------:|----:|:------:|
+| `insanisfiction.armbian.de` | Hetzner Germany | 176 | 375 GB | active |
+| `ampere-1` | GitHub | 128 | 500 GB | active |
+| `kspace` | Imola | 128 | 264 GB | active |
+| `github.com` | GitHub | 40 | 137 GB | active |
+| `3950x` | Armbian Datacenter | 32 | 125 GB | active |
+| `game.imola.armbian.com` | Imola | 32 | 132 GB | active |
+| `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | active |
+| `stpete-runner.armbian.com` | JetHome | 24 | 64 GB | active |
+| `geekom` | Mirrors | 20 | 62 GB | active |
+| `cats` | Auroradev Las Vegas | 16 | 32 GB | active |
+| `mind` | GitHub | 16 | 16 GB | ⚠️ offline |
+| `oregon-uni-1.armbian.com` | Oregon UNI | 16 | 31 GB | active |
+| `oregon-uni-2.armbian.com` | Oregon UNI | 16 | 31 GB | active |
+| `repo.armbian.com` | Netcup Germany | 10 | 16 GB | active |
+| `mt7925e` | Kspace Estonia | 8 | 16 GB | active |
+| `nanopim6` | GitHub | 8 | 32 GB | ⚠️ offline |
+| `rock5-16g-aarch64-01-04` | Rock 5 #1 | 8 | 16 GB | ⚠️ offline |
+| `rock5-16g-aarch64-05-08` | Rock 5 #2 | 8 | 16 GB | ⚠️ offline |
+| `werner` | Hetzner Germany | 8 | 31 GB | active |
+| `big-arm` | LaneCloud | 4 | 24 GB | active |
+
+<!-- build-machinery:end -->

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,7 +15,7 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (matched by its label), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM.
+**20** servers — **16** active, **4** offline · **730** CPU threads (**690** active) · **2045** GB RAM · **235** runners.
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|

--- a/docs/status/build-machinery.md
+++ b/docs/status/build-machinery.md
@@ -15,7 +15,7 @@ runner processes each server hosts (from the
 
 _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runner`. The **Runners** column is the number of GitHub runner processes registered on that server (its runners are named `<server>-NN`), falling back to the value recorded in NetBox when GitHub can't be queried._
 
-**15** servers — **13** active, **2** offline · **658** CPU threads (**622** active) · **1846** GB RAM · **245** runners (**104** online).
+**12** servers — **12** active, **0** offline · **614** CPU threads (**614** active) · **1683** GB RAM · **233** runners (**104** online).
 
 | Server | Location | Threads | RAM | Runners | Status |
 |:-------|:---------|--------:|----:|--------:|:------:|
@@ -23,16 +23,13 @@ _Build servers from [NetBox](https://netbox.armbian.com/), role `userlevel-runne
 | `ampere-1` | Armbian Datacenter | 128 | 512 GB | 64 | active |
 | `kspace` | Kspace Estonia | 128 | 256 GB | 32 | active |
 | `github` | GitHub | 40 | 137 GB | 20 | active |
-| `3950x` | Armbian Datacenter | 32 | 125 GB | 8 | ⚠️ decommissioning |
 | `rack-ryzen` | Armbian Datacenter | 32 | 125 GB | 15 | active |
 | `stpete` | JetHome | 24 | 64 GB | 6 | active |
-| `geekom` | Mirrors | 20 | 62 GB | 8 | active |
+| `geekom` | Armbian Datacenter | 20 | 62 GB | 8 | active |
 | `cats` | Auroradev Las Vegas | 16 | 32 GB | 6 | active |
-| `oregonalfa` | Oregon UNI | 16 | 31 GB | 6 | active |
-| `oregonbeta` | Oregon UNI | 16 | 31 GB | 6 | active |
+| `oregonalfa` | Oregon UNI | 16 | 32 GB | 6 | active |
+| `oregonbeta` | Oregon UNI | 16 | 32 GB | 6 | active |
 | `repoassembly` | Netcup Germany | 10 | 16 GB | 26 | active |
-| `mt7925e` | Kspace Estonia | 8 | 16 GB | 2 | active |
 | `werner` | Hetzner Germany | 8 | 31 GB | 4 | active |
-| `big-arm` | LaneCloud | 4 | 24 GB | 2 | ⚠️ offline |
 
 <!-- build-machinery:end -->

--- a/docs/status/index.md
+++ b/docs/status/index.md
@@ -53,6 +53,10 @@ refreshed by scheduled jobs, not written by hand.
     `apt.armbian.com` status — package and kernel versions, kernel-family
     drift and header gaps.
 
+- :material-server: **[Build machinery](build-machinery.md)**
+
+    The self-hosted runner fleet — CPU-thread capacity, memory and location.
+
 </div>
 
 !!! note "Prototype"

--- a/docs/status/index.md
+++ b/docs/status/index.md
@@ -55,7 +55,7 @@ refreshed by scheduled jobs, not written by hand.
 
 - :material-server: **[Build machinery](build-machinery.md)**
 
-    The self-hosted runner fleet — CPU-thread capacity, memory and location.
+    The build servers — CPU-thread capacity, memory, location and runner count.
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,6 +346,7 @@ nav:
         - 'Mirrors' : 'status/mirrors.md'
         - 'Download images' : 'status/download-images.md'
         - 'Package repository' : 'status/package-repository.md'
+        - 'Build machinery' : 'status/build-machinery.md'
 
   - 'COMMUNITY' :
         - 'Forums' : 'community/forums.md'

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -44,6 +44,10 @@ def netbox_get(api, token, path):
     results = []
     url = f"{api}{path}"
     while url:
+        # never send the token over cleartext (api may be misconfigured, and the
+        # `next` URL is server-provided)
+        if not url.lower().startswith("https://"):
+            sys.exit(f"error: refusing to send the NetBox token over non-HTTPS URL: {url}")
         req = urllib.request.Request(url, headers={
             "Authorization": f"Token {token}",
             "Accept": "application/json",

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Generate a Markdown status report for the Armbian build machinery — the
-self-hosted runner fleet — from NetBox.
+build servers — from NetBox, with the live runner count from GitHub.
 
-Reads the "Userlevel runner" virtual machines (role=userlevel-runner) and
-reports each runner's location, CPU thread count and memory, plus the fleet
-totals (the CPU-thread capacity).
+Reads the build servers (NetBox VMs with role=userlevel-runner) and reports
+each server's location, CPU thread count and memory, plus the fleet totals
+(the CPU-thread capacity). The number of GitHub runner processes on each
+server is read from GitHub by matching the server name to a runner label.
 
 It can also list the org's GitHub Actions self-hosted runners grouped by
 label (keyword), when a token with the runners permission is available.
@@ -30,6 +31,9 @@ import urllib.request
 DEFAULT_API = "https://netbox.armbian.com/api"
 ROLE = "userlevel-runner"
 DEFAULT_ORG = "armbian"
+# GitHub-assigned default labels; the runner's own name comes from what's left.
+GH_DEFAULT_LABELS = {"self-hosted", "linux", "macos", "windows",
+                     "x64", "x86", "arm", "arm64"}
 
 
 def netbox_get(api, token, path):
@@ -73,37 +77,27 @@ def github_runners(org, token):
     return runners
 
 
-def github_section(org, token):
-    """Markdown for the org runners grouped by label; '' if unavailable."""
+def github_runner_counts(org, token):
+    """Map a machine name (via its runner label) to the number of registered
+    GitHub runners carrying it. Returns None when the org runners can't be read
+    (no/insufficient token), so the caller can leave the column blank.
+
+    A machine hosts one or more runner processes, each registered with the
+    machine's name as a label; counting runners per label gives runners-per-machine.
+    """
     try:
         runners = github_runners(org, token)
     except Exception as e:
         print(f"::warning::GitHub runners unavailable: {e}", file=sys.stderr)
-        return ""
-    if not runners:
-        return ""
-    online = [r for r in runners if r.get("status") == "online"]
-    busy = [r for r in runners if r.get("busy")]
-    per_label, online_per_label = collections.Counter(), collections.Counter()
+        return None
+    per_label = collections.Counter()
     for r in runners:
         for lbl in r.get("labels", []):
-            per_label[lbl["name"]] += 1
-            if r.get("status") == "online":
-                online_per_label[lbl["name"]] += 1
-
-    out = ["## Runners by label", ""]
-    out.append(f"_Self-hosted runners registered to the [`{org}`]"
-               f"(https://github.com/{org}) GitHub organisation, grouped by label._")
-    out.append("")
-    out.append(f"**{len(runners)}** runners — **{len(online)}** online, "
-               f"**{len(runners) - len(online)}** offline, **{len(busy)}** busy.")
-    out.append("")
-    out.append("| Label | Runners | Online |")
-    out.append("|:------|--------:|-------:|")
-    for label, n in sorted(per_label.items(), key=lambda kv: (-kv[1], kv[0])):
-        out.append(f"| `{label}` | {n} | {online_per_label[label]} |")
-    out.append("")
-    return "\n".join(out)
+            name = lbl["name"].lower()
+            if name not in GH_DEFAULT_LABELS:
+                per_label[name] += 1
+    online = sum(1 for r in runners if r.get("status") == "online")
+    return {"labels": per_label, "total": len(runners), "online": online}
 
 
 def build_report(api, token, gh_org=None, gh_token=None):
@@ -126,28 +120,36 @@ def build_report(api, token, gh_org=None, gh_token=None):
     active_threads = sum(r["threads"] for r in active)
     total_ram = sum(r["ram"] for r in rows)
 
+    # Runners-per-machine from GitHub (needs the runners token); None -> "—".
+    gh = github_runner_counts(gh_org or DEFAULT_ORG, gh_token) if gh_token else None
+
+    def runners_cell(name):
+        if gh is None:
+            return "—"
+        return str(gh["labels"].get(name.lower(), 0))
+
     out = []
-    out.append("## Runner fleet")
+    out.append("## Build servers")
     out.append("")
-    out.append(f"_Self-hosted runners from [NetBox](https://netbox.armbian.com/), "
-               f"role `{ROLE}`._")
+    out.append(f"_Build servers from [NetBox](https://netbox.armbian.com/), "
+               f"role `{ROLE}`. The **Runners** column is the number of GitHub "
+               f"runner processes registered on that server (matched by its label)._")
     out.append("")
-    out.append(f"**{len(rows)}** runners — **{len(active)}** active, "
+    summary = (f"**{len(rows)}** servers — **{len(active)}** active, "
                f"**{len(rows) - len(active)}** offline · "
                f"**{total_threads}** CPU threads (**{active_threads}** active) · "
-               f"**{total_ram}** GB RAM.")
+               f"**{total_ram}** GB RAM")
+    if gh is not None:
+        summary += f" · **{gh['total']}** GitHub runners (**{gh['online']}** online)"
+    out.append(summary + ".")
     out.append("")
-    out.append("| Runner | Location | Threads | RAM | Status |")
-    out.append("|:-------|:---------|--------:|----:|:------:|")
+    out.append("| Server | Location | Threads | RAM | Runners | Status |")
+    out.append("|:-------|:---------|--------:|----:|--------:|:------:|")
     for r in rows:
         status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
-        out.append(f"| `{r['name']}` | {r['loc']} | {r['threads']} | {r['ram']} GB | {status} |")
+        out.append(f"| `{r['name']}` | {r['loc']} | {r['threads']} | {r['ram']} GB "
+                   f"| {runners_cell(r['name'])} | {status} |")
     out.append("")
-
-    if gh_token:
-        gh = github_section(gh_org or DEFAULT_ORG, gh_token)
-        if gh:
-            out.append(gh)
 
     return "\n".join(out)
 

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -90,14 +90,18 @@ def github_runner_counts(org, token):
     except Exception as e:
         print(f"::warning::GitHub runners unavailable: {e}", file=sys.stderr)
         return None
-    per_label = collections.Counter()
+    per_label, online_label = collections.Counter(), collections.Counter()
     for r in runners:
+        is_online = r.get("status") == "online"
         for lbl in r.get("labels", []):
             name = lbl["name"].lower()
             if name not in GH_DEFAULT_LABELS:
                 per_label[name] += 1
+                if is_online:
+                    online_label[name] += 1
     online = sum(1 for r in runners if r.get("status") == "online")
-    return {"labels": per_label, "total": len(runners), "online": online}
+    return {"labels": per_label, "online_labels": online_label,
+            "total": len(runners), "online": online}
 
 
 def build_report(api, token, gh_org=None, gh_token=None):
@@ -126,16 +130,20 @@ def build_report(api, token, gh_org=None, gh_token=None):
     active_threads = sum(r["threads"] for r in active)
     total_ram = sum(r["ram"] for r in rows)
 
-    # Runners-per-machine from GitHub (needs the runners token); None -> "—".
+    # Resolve a runner count (and online count) per server: live from GitHub
+    # matched by the label when we can query it, otherwise the NetBox value.
     gh = github_runner_counts(gh_org or DEFAULT_ORG, gh_token) if gh_token else None
+    for r in rows:
+        key = (r["label"] or "").lower()
+        if gh is not None and key:
+            r["rcount"] = gh["labels"].get(key, 0)
+            r["ronline"] = gh["online_labels"].get(key, 0)
+        else:
+            r["rcount"] = r.get("nb_runners")   # may be None
+            r["ronline"] = None
 
-    def runners_cell(row):
-        # live GitHub answer (0 if the label carries none) when we can query it,
-        # otherwise NetBox's stored count as a fallback
-        if gh is not None and row["label"]:
-            return str(gh["labels"].get(row["label"].lower(), 0))
-        nb = row.get("nb_runners")
-        return str(nb) if nb is not None else "—"
+    total_runners = sum(r["rcount"] for r in rows if r["rcount"] is not None)
+    online_runners = sum(r["ronline"] for r in rows if r["ronline"] is not None)
 
     out = []
     out.append("## Build servers")
@@ -148,18 +156,22 @@ def build_report(api, token, gh_org=None, gh_token=None):
     summary = (f"**{len(rows)}** servers — **{len(active)}** active, "
                f"**{len(rows) - len(active)}** offline · "
                f"**{total_threads}** CPU threads (**{active_threads}** active) · "
-               f"**{total_ram}** GB RAM")
+               f"**{total_ram}** GB RAM · **{total_runners}** runners")
     if gh is not None:
-        summary += f" · **{gh['total']}** GitHub runners (**{gh['online']}** online)"
+        summary += f" (**{online_runners}** online)"
     out.append(summary + ".")
     out.append("")
     out.append("| Server | Location | Threads | RAM | Runners | Status |")
     out.append("|:-------|:---------|--------:|----:|--------:|:------:|")
     for r in rows:
-        status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
+        if gh is not None and r["label"]:
+            status = "online" if r["ronline"] else "⚠️ offline"
+        else:
+            status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
         name = r["label"] or r["name"]
+        runners = str(r["rcount"]) if r["rcount"] is not None else "—"
         out.append(f"| `{name}` | {r['loc']} | {r['threads']} | {r['ram']} GB "
-                   f"| {runners_cell(r)} | {status} |")
+                   f"| {runners} | {status} |")
     out.append("")
 
     return "\n".join(out)

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Generate a Markdown status report for the Armbian build machinery — the
+self-hosted runner fleet — from NetBox.
+
+Reads the "Userlevel runner" virtual machines (role=userlevel-runner) and
+reports each runner's location, CPU thread count and memory, plus the fleet
+totals (the CPU-thread capacity).
+
+It can also list the org's GitHub Actions self-hosted runners grouped by
+label (keyword), when a token with the runners permission is available.
+
+Environment:
+    NETBOX_TOKEN       required — a read-only NetBox API token
+    NETBOX_API         NetBox API base (default https://netbox.armbian.com/api)
+    GH_RUNNERS_TOKEN   optional — GitHub token with admin:org (or the
+                       fine-grained "self-hosted runners" org permission);
+                       falls back to GITHUB_TOKEN. When absent, the GitHub
+                       section is skipped.
+    GH_ORG             GitHub org for the runner listing (default: armbian)
+
+Prints Markdown to stdout (or --output FILE).
+"""
+import argparse
+import collections
+import json
+import os
+import sys
+import urllib.request
+
+DEFAULT_API = "https://netbox.armbian.com/api"
+ROLE = "userlevel-runner"
+DEFAULT_ORG = "armbian"
+
+
+def netbox_get(api, token, path):
+    """GET an API path, following pagination, returning all results."""
+    results = []
+    url = f"{api}{path}"
+    while url:
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Token {token}",
+            "Accept": "application/json",
+        })
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.load(resp)
+        results.extend(data.get("results", []))
+        url = data.get("next")
+    return results
+
+
+def gb(mb):
+    return round((mb or 0) / 1024)
+
+
+def github_runners(org, token):
+    """All self-hosted runners registered to the org (needs admin:org / the
+    runners permission). Returns [] and re-raises nothing on failure."""
+    runners, page = [], 1
+    while True:
+        url = f"https://api.github.com/orgs/{org}/actions/runners?per_page=100&page={page}"
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        })
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.load(resp)
+        batch = data.get("runners", [])
+        runners.extend(batch)
+        if not batch or len(runners) >= data.get("total_count", 0):
+            break
+        page += 1
+    return runners
+
+
+def github_section(org, token):
+    """Markdown for the org runners grouped by label; '' if unavailable."""
+    try:
+        runners = github_runners(org, token)
+    except Exception as e:
+        print(f"::warning::GitHub runners unavailable: {e}", file=sys.stderr)
+        return ""
+    if not runners:
+        return ""
+    online = [r for r in runners if r.get("status") == "online"]
+    busy = [r for r in runners if r.get("busy")]
+    per_label, online_per_label = collections.Counter(), collections.Counter()
+    for r in runners:
+        for lbl in r.get("labels", []):
+            per_label[lbl["name"]] += 1
+            if r.get("status") == "online":
+                online_per_label[lbl["name"]] += 1
+
+    out = ["## Runners by label", ""]
+    out.append(f"_Self-hosted runners registered to the [`{org}`]"
+               f"(https://github.com/{org}) GitHub organisation, grouped by label._")
+    out.append("")
+    out.append(f"**{len(runners)}** runners — **{len(online)}** online, "
+               f"**{len(runners) - len(online)}** offline, **{len(busy)}** busy.")
+    out.append("")
+    out.append("| Label | Runners | Online |")
+    out.append("|:------|--------:|-------:|")
+    for label, n in sorted(per_label.items(), key=lambda kv: (-kv[1], kv[0])):
+        out.append(f"| `{label}` | {n} | {online_per_label[label]} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def build_report(api, token, gh_org=None, gh_token=None):
+    vms = netbox_get(api, token, f"/virtualization/virtual-machines/?role={ROLE}&limit=500")
+    rows = []
+    for v in vms:
+        loc = (v.get("site") or {}).get("name") or (v.get("cluster") or {}).get("name") or "—"
+        rows.append({
+            "name": v["name"],
+            "status": v["status"]["value"],
+            "threads": int(v.get("vcpus") or 0),
+            "ram": gb(v.get("memory")),
+            "loc": loc,
+        })
+    # biggest machines first; the capacity view
+    rows.sort(key=lambda r: (-r["threads"], r["name"]))
+
+    active = [r for r in rows if r["status"] == "active"]
+    total_threads = sum(r["threads"] for r in rows)
+    active_threads = sum(r["threads"] for r in active)
+    total_ram = sum(r["ram"] for r in rows)
+
+    out = []
+    out.append("## Runner fleet")
+    out.append("")
+    out.append(f"_Self-hosted runners from [NetBox](https://netbox.armbian.com/), "
+               f"role `{ROLE}`._")
+    out.append("")
+    out.append(f"**{len(rows)}** runners — **{len(active)}** active, "
+               f"**{len(rows) - len(active)}** offline · "
+               f"**{total_threads}** CPU threads (**{active_threads}** active) · "
+               f"**{total_ram}** GB RAM.")
+    out.append("")
+    out.append("| Runner | Location | Threads | RAM | Status |")
+    out.append("|:-------|:---------|--------:|----:|:------:|")
+    for r in rows:
+        status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
+        out.append(f"| `{r['name']}` | {r['loc']} | {r['threads']} | {r['ram']} GB | {status} |")
+    out.append("")
+
+    if gh_token:
+        gh = github_section(gh_org or DEFAULT_ORG, gh_token)
+        if gh:
+            out.append(gh)
+
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--api", default=os.environ.get("NETBOX_API") or DEFAULT_API)
+    ap.add_argument("--org", default=os.environ.get("GH_ORG") or DEFAULT_ORG)
+    ap.add_argument("--output", help="write Markdown here (default: stdout)")
+    args = ap.parse_args()
+
+    token = os.environ.get("NETBOX_TOKEN")
+    if not token:
+        sys.exit("error: NETBOX_TOKEN is required (read-only NetBox API token)")
+    gh_token = os.environ.get("GH_RUNNERS_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    report = build_report(args.api.rstrip("/"), token, gh_org=args.org, gh_token=gh_token)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -54,9 +54,8 @@ def netbox_get(api, token, path):
 
 
 def gb(mb):
-    # NetBox stores memory in MB as a decimal GB value (512 GB -> 512000 MB),
-    # so divide by 1000 to show the number that was entered.
-    return round((mb or 0) / 1000)
+    # NetBox stores memory in MB (binary: 512 GB -> 524288 MB).
+    return round((mb or 0) / 1024)
 
 
 def github_runners(org, token):

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -54,7 +54,9 @@ def netbox_get(api, token, path):
 
 
 def gb(mb):
-    return round((mb or 0) / 1024)
+    # NetBox stores memory in MB as a decimal GB value (512 GB -> 512000 MB),
+    # so divide by 1000 to show the number that was entered.
+    return round((mb or 0) / 1000)
 
 
 def github_runners(org, token):

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -164,10 +164,9 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out.append("| Server | Location | Threads | RAM | Runners | Status |")
     out.append("|:-------|:---------|--------:|----:|--------:|:------:|")
     for r in rows:
-        if r["ronline"] is not None:               # matched on GitHub
-            status = "online" if r["ronline"] else "⚠️ offline"
-        else:                                      # NetBox fallback
-            status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
+        # status always from NetBox: some servers are powered on demand, so
+        # their runners can read offline on GitHub while the server is fine
+        status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
         name = r["label"] or r["name"]
         runners = str(r["rcount"]) if r["rcount"] is not None else "—"
         out.append(f"| `{name}` | {r['loc']} | {r['threads']} | {r['ram']} GB "

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -2,7 +2,7 @@
 """Generate a Markdown status report for the Armbian build machinery — the
 build servers — from NetBox, with the live runner count from GitHub.
 
-Reads the build servers (NetBox VMs with role=userlevel-runner) and reports
+Reads the build servers (NetBox VMs tagged github-runner) and reports
 each server's location, CPU thread count and memory, plus the fleet totals
 (the CPU-thread capacity). The number of GitHub runner processes on each
 server is read from GitHub by matching the server name to a runner label.
@@ -30,7 +30,9 @@ import sys
 import urllib.request
 
 DEFAULT_API = "https://netbox.armbian.com/api"
-ROLE = "userlevel-runner"
+# Build runners are identified by a tag (a VM may have the mirror/other role
+# yet also host runners), not by role.
+TAG = "github-runner"
 DEFAULT_ORG = "armbian"
 # Runners are named "<server>-01", "<server>-02", ...; strip the trailing index
 # to group a server's runners (e.g. insa-trixie-01 -> insa-trixie).
@@ -105,7 +107,7 @@ def github_runner_counts(org, token):
 
 
 def build_report(api, token, gh_org=None, gh_token=None):
-    vms = netbox_get(api, token, f"/virtualization/virtual-machines/?role={ROLE}&limit=500")
+    vms = netbox_get(api, token, f"/virtualization/virtual-machines/?tag={TAG}&limit=500")
     rows = []
     for v in vms:
         loc = (v.get("site") or {}).get("name") or (v.get("cluster") or {}).get("name") or "—"
@@ -149,7 +151,7 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out.append("## Build servers")
     out.append("")
     out.append(f"_Build servers from [NetBox](https://netbox.armbian.com/), "
-               f"role `{ROLE}`. The **Runners** column is the number of GitHub "
+               f"tagged `{TAG}`. The **Runners** column is the number of GitHub "
                f"runner processes registered on that server (its runners are named "
                f"`<server>-NN`), falling back to the value recorded in NetBox when "
                f"GitHub can't be queried._")

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -25,15 +25,16 @@ import argparse
 import collections
 import json
 import os
+import re
 import sys
 import urllib.request
 
 DEFAULT_API = "https://netbox.armbian.com/api"
 ROLE = "userlevel-runner"
 DEFAULT_ORG = "armbian"
-# GitHub-assigned default labels; the runner's own name comes from what's left.
-GH_DEFAULT_LABELS = {"self-hosted", "linux", "macos", "windows",
-                     "x64", "x86", "arm", "arm64"}
+# Runners are named "<server>-01", "<server>-02", ...; strip the trailing index
+# to group a server's runners (e.g. insa-trixie-01 -> insa-trixie).
+RUNNER_INDEX = re.compile(r"-\d+$")
 
 
 def netbox_get(api, token, path):
@@ -90,17 +91,15 @@ def github_runner_counts(org, token):
     except Exception as e:
         print(f"::warning::GitHub runners unavailable: {e}", file=sys.stderr)
         return None
-    per_label, online_label = collections.Counter(), collections.Counter()
+    per_server, online_server = collections.Counter(), collections.Counter()
     for r in runners:
-        is_online = r.get("status") == "online"
-        for lbl in r.get("labels", []):
-            name = lbl["name"].lower()
-            if name not in GH_DEFAULT_LABELS:
-                per_label[name] += 1
-                if is_online:
-                    online_label[name] += 1
+        # a server's runners are named "<server>-NN"; group by the prefix
+        key = RUNNER_INDEX.sub("", r.get("name", "")).lower()
+        per_server[key] += 1
+        if r.get("status") == "online":
+            online_server[key] += 1
     online = sum(1 for r in runners if r.get("status") == "online")
-    return {"labels": per_label, "online_labels": online_label,
+    return {"servers": per_server, "online_servers": online_server,
             "total": len(runners), "online": online}
 
 
@@ -134,12 +133,12 @@ def build_report(api, token, gh_org=None, gh_token=None):
     # matched by the label when we can query it, otherwise the NetBox value.
     gh = github_runner_counts(gh_org or DEFAULT_ORG, gh_token) if gh_token else None
     for r in rows:
-        key = (r["label"] or "").lower()
-        if gh is not None and key:
-            r["rcount"] = gh["labels"].get(key, 0)
-            r["ronline"] = gh["online_labels"].get(key, 0)
+        key = (r["label"] or r["name"] or "").lower()
+        if gh is not None and key in gh["servers"]:
+            r["rcount"] = gh["servers"][key]
+            r["ronline"] = gh["online_servers"].get(key, 0)
         else:
-            r["rcount"] = r.get("nb_runners")   # may be None
+            r["rcount"] = r.get("nb_runners")   # NetBox fallback (may be None)
             r["ronline"] = None
 
     total_runners = sum(r["rcount"] for r in rows if r["rcount"] is not None)
@@ -150,8 +149,9 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out.append("")
     out.append(f"_Build servers from [NetBox](https://netbox.armbian.com/), "
                f"role `{ROLE}`. The **Runners** column is the number of GitHub "
-               f"runner processes registered on that server (matched by its label), "
-               f"falling back to the value recorded in NetBox when GitHub can't be queried._")
+               f"runner processes registered on that server (its runners are named "
+               f"`<server>-NN`), falling back to the value recorded in NetBox when "
+               f"GitHub can't be queried._")
     out.append("")
     summary = (f"**{len(rows)}** servers — **{len(active)}** active, "
                f"**{len(rows) - len(active)}** offline · "
@@ -164,9 +164,9 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out.append("| Server | Location | Threads | RAM | Runners | Status |")
     out.append("|:-------|:---------|--------:|----:|--------:|:------:|")
     for r in rows:
-        if gh is not None and r["label"]:
+        if r["ronline"] is not None:               # matched on GitHub
             status = "online" if r["ronline"] else "⚠️ offline"
-        else:
+        else:                                      # NetBox fallback
             status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
         name = r["label"] or r["name"]
         runners = str(r["rcount"]) if r["rcount"] is not None else "—"

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -105,8 +105,12 @@ def build_report(api, token, gh_org=None, gh_token=None):
     rows = []
     for v in vms:
         loc = (v.get("site") or {}).get("name") or (v.get("cluster") or {}).get("name") or "—"
+        cf = v.get("custom_fields") or {}
         rows.append({
             "name": v["name"],
+            # the GitHub runners label lives in a NetBox custom field; it is the
+            # server's display name here and the key to count runners on GitHub
+            "label": cf.get("github_label"),
             "status": v["status"]["value"],
             "threads": int(v.get("vcpus") or 0),
             "ram": gb(v.get("memory")),
@@ -123,10 +127,10 @@ def build_report(api, token, gh_org=None, gh_token=None):
     # Runners-per-machine from GitHub (needs the runners token); None -> "—".
     gh = github_runner_counts(gh_org or DEFAULT_ORG, gh_token) if gh_token else None
 
-    def runners_cell(name):
-        if gh is None:
+    def runners_cell(label):
+        if gh is None or not label:
             return "—"
-        return str(gh["labels"].get(name.lower(), 0))
+        return str(gh["labels"].get(label.lower(), 0))
 
     out = []
     out.append("## Build servers")
@@ -147,8 +151,9 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out.append("|:-------|:---------|--------:|----:|--------:|:------:|")
     for r in rows:
         status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
-        out.append(f"| `{r['name']}` | {r['loc']} | {r['threads']} | {r['ram']} GB "
-                   f"| {runners_cell(r['name'])} | {status} |")
+        name = r["label"] or r["name"]
+        out.append(f"| `{name}` | {r['loc']} | {r['threads']} | {r['ram']} GB "
+                   f"| {runners_cell(r['label'])} | {status} |")
     out.append("")
 
     return "\n".join(out)

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -150,12 +150,6 @@ def build_report(api, token, gh_org=None, gh_token=None):
     out = []
     out.append("## Build servers")
     out.append("")
-    out.append(f"_Build servers from [NetBox](https://netbox.armbian.com/), "
-               f"tagged `{TAG}`. The **Runners** column is the number of GitHub "
-               f"runner processes registered on that server (its runners are named "
-               f"`<server>-NN`), falling back to the value recorded in NetBox when "
-               f"GitHub can't be queried._")
-    out.append("")
     n_off = len(rows) - len(active)
     servers = f"**{len(rows)}** servers" + (f" (**{n_off}** offline)" if n_off else "")
     threads = f"**{total_threads}** threads" + (

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -111,6 +111,8 @@ def build_report(api, token, gh_org=None, gh_token=None):
             # the GitHub runners label lives in a NetBox custom field; it is the
             # server's display name here and the key to count runners on GitHub
             "label": cf.get("github_label"),
+            # NetBox's stored runner count, used when GitHub can't be queried
+            "nb_runners": cf.get("runners"),
             "status": v["status"]["value"],
             "threads": int(v.get("vcpus") or 0),
             "ram": gb(v.get("memory")),
@@ -127,17 +129,21 @@ def build_report(api, token, gh_org=None, gh_token=None):
     # Runners-per-machine from GitHub (needs the runners token); None -> "—".
     gh = github_runner_counts(gh_org or DEFAULT_ORG, gh_token) if gh_token else None
 
-    def runners_cell(label):
-        if gh is None or not label:
-            return "—"
-        return str(gh["labels"].get(label.lower(), 0))
+    def runners_cell(row):
+        # live GitHub answer (0 if the label carries none) when we can query it,
+        # otherwise NetBox's stored count as a fallback
+        if gh is not None and row["label"]:
+            return str(gh["labels"].get(row["label"].lower(), 0))
+        nb = row.get("nb_runners")
+        return str(nb) if nb is not None else "—"
 
     out = []
     out.append("## Build servers")
     out.append("")
     out.append(f"_Build servers from [NetBox](https://netbox.armbian.com/), "
                f"role `{ROLE}`. The **Runners** column is the number of GitHub "
-               f"runner processes registered on that server (matched by its label)._")
+               f"runner processes registered on that server (matched by its label), "
+               f"falling back to the value recorded in NetBox when GitHub can't be queried._")
     out.append("")
     summary = (f"**{len(rows)}** servers — **{len(active)}** active, "
                f"**{len(rows) - len(active)}** offline · "
@@ -153,7 +159,7 @@ def build_report(api, token, gh_org=None, gh_token=None):
         status = "active" if r["status"] == "active" else f"⚠️ {r['status']}"
         name = r["label"] or r["name"]
         out.append(f"| `{name}` | {r['loc']} | {r['threads']} | {r['ram']} GB "
-                   f"| {runners_cell(r['label'])} | {status} |")
+                   f"| {runners_cell(r)} | {status} |")
     out.append("")
 
     return "\n".join(out)

--- a/tools/build-machinery-status.py
+++ b/tools/build-machinery-status.py
@@ -154,13 +154,13 @@ def build_report(api, token, gh_org=None, gh_token=None):
                f"`<server>-NN`), falling back to the value recorded in NetBox when "
                f"GitHub can't be queried._")
     out.append("")
-    summary = (f"**{len(rows)}** servers — **{len(active)}** active, "
-               f"**{len(rows) - len(active)}** offline · "
-               f"**{total_threads}** CPU threads (**{active_threads}** active) · "
-               f"**{total_ram}** GB RAM · **{total_runners}** runners")
-    if gh is not None:
-        summary += f" (**{online_runners}** online)"
-    out.append(summary + ".")
+    n_off = len(rows) - len(active)
+    servers = f"**{len(rows)}** servers" + (f" (**{n_off}** offline)" if n_off else "")
+    threads = f"**{total_threads}** threads" + (
+        f" (**{active_threads}** active)" if active_threads != total_threads else "")
+    runners = f"**{total_runners}** runners" + (
+        f" (**{online_runners}** online)" if gh is not None else "")
+    out.append(" · ".join([servers, threads, f"**{total_ram}** GB RAM", runners]) + ".")
     out.append("")
     out.append("| Server | Location | Threads | RAM | Runners | Status |")
     out.append("|:-------|:---------|--------:|----:|--------:|:------:|")


### PR DESCRIPTION
New STATUS card: the **build machinery** — the self-hosted runner fleet.

### `tools/build-machinery-status.py`
- **NetBox** (`role=userlevel-runner`): every runner's **CPU threads**, **memory** and **location**, plus fleet totals — the CPU-thread capacity. Current snapshot: **20 runners — 16 active, 4 offline · 730 CPU threads (690 active) · ~2 TB RAM**.
- **GitHub** (optional): when a token with the runners permission is present, the org's self-hosted runners **grouped by label** (keyword) with online counts.
- Reads `NETBOX_TOKEN` / `NETBOX_API` and `GH_RUNNERS_TOKEN` (falls back to `GITHUB_TOKEN`) from the environment; the GitHub section is skipped when the token can't list org runners.

### `docs/status/build-machinery.md`
Intro + `<!-- build-machinery:start/end -->` block, shipped **pre-filled** with the NetBox fleet (the GitHub-by-label section fills in on the first CI run).

### `build-machinery-status.yml`
Scheduled (daily) + manual dispatch — needs secrets, so no PR trigger. Passes `secrets.NETBOX_TOKEN`, `secrets.NETBOX_API`, `secrets.RUNNERS`; writes the report to the job summary, splices it into the page (fail-closed markers) and opens an auto-update PR.

Added **Build machinery** to the STATUS nav and Overview. No secrets are committed (verified).

> The GitHub runners-by-label section couldn't be tested locally (org-runners API needs `admin:org`); it's wired to `secrets.RUNNERS` and will populate on the first scheduled run. If that token lacks the permission the section is simply omitted.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1046"><kbd><br> Open WWW preview <br></kbd></a>