### PR TITLE
ci(status): scope auto-PRs to their page + zero-touch auto-merge

### DIFF
--- a/.github/workflows/apt-repo-status.yml
+++ b/.github/workflows/apt-repo-status.yml
@@ -74,6 +74,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: docs/status/package-repository.md
           commit-message: '`Automatic` package repository status update'
           signoff: false
           branch: auto-update-apt-status

--- a/.github/workflows/build-machinery-status.yml
+++ b/.github/workflows/build-machinery-status.yml
@@ -68,6 +68,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: docs/status/build-machinery.md
           commit-message: '`Automatic` build machinery status update'
           signoff: false
           branch: auto-update-build-machinery

--- a/.github/workflows/download-images-status.yml
+++ b/.github/workflows/download-images-status.yml
@@ -70,6 +70,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: docs/status/download-images.md
           commit-message: '`Automatic` download images status update'
           signoff: false
           branch: auto-update-download-images


### PR DESCRIPTION
Two fixes for the `Automatic` status update PRs (build-machinery, apt, download-images, mirrors).

### 1. Only commit the page (fixes #1047)
The workflows generate their report/marker files in the repo root, and `create-pull-request` commits *all* changes — so the auto-PR added `block.md`/`report.md` instead of the page. Each PR step now uses `add-paths: docs/status/<page>.md`; temp files are ignored, and an unchanged page opens no PR. (The mirror workflow was already safe via `path: documentation`.)

### 2. Zero-touch auto-merge
`main` requires **1 approving review** and has **no required status checks**. After opening the PR, the workflow now:
- **approves** it with a maintainer PAT — `secrets.AUTOMERGE_TOKEN` (the Actions bot can't approve its own PR), then
- queues **squash auto-merge** (`gh pr merge --squash --auto`), which lands once the review requirement is satisfied.

Both steps are `continue-on-error`, so if the secret is absent the PR just stays open for manual review — nothing breaks.

> **Action needed:** create the **`AUTOMERGE_TOKEN`** secret — a PAT from a maintainer account (org member with write) that can approve PRs: classic PAT with `repo`, or fine-grained with *Pull requests: write* + *Contents: read* on this repo. It must be a **different identity than the Actions bot**. Until it's set, the auto-approve step no-ops and PRs stay manual.