### PR TITLE
ci(status): zero-touch auto-merge for the status update PRs

### DIFF
--- a/.github/workflows/apt-repo-status.yml
+++ b/.github/workflows/apt-repo-status.yml
@@ -94,7 +94,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           # the Actions bot cannot approve its own PR, so approve with a

--- a/.github/workflows/apt-repo-status.yml
+++ b/.github/workflows/apt-repo-status.yml
@@ -70,6 +70,7 @@ jobs:
           ' "$PAGE" > tmp.md && mv tmp.md "$PAGE"
 
       - name: Create Pull Request
+        id: cpr
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/create-pull-request@v8
         with:
@@ -87,3 +88,16 @@ jobs:
           labels: |
             Needs review
           draft: false
+
+      - name: Approve and enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          # the Actions bot cannot approve its own PR, so approve with a
+          # maintainer PAT, then queue squash auto-merge (delete branch on merge)
+          GH_TOKEN="$APPROVE_TOKEN" gh pr review "$PR" --approve
+          gh pr merge "$PR" --squash --auto

--- a/.github/workflows/build-machinery-status.yml
+++ b/.github/workflows/build-machinery-status.yml
@@ -65,6 +65,7 @@ jobs:
           ' "$PAGE" > tmp.md && mv tmp.md "$PAGE"
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,3 +82,16 @@ jobs:
           labels: |
             Needs review
           draft: false
+
+      - name: Approve and enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          # the Actions bot cannot approve its own PR, so approve with a
+          # maintainer PAT, then queue squash auto-merge (delete branch on merge)
+          GH_TOKEN="$APPROVE_TOKEN" gh pr review "$PR" --approve
+          gh pr merge "$PR" --squash --auto

--- a/.github/workflows/build-machinery-status.yml
+++ b/.github/workflows/build-machinery-status.yml
@@ -88,7 +88,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           # the Actions bot cannot approve its own PR, so approve with a

--- a/.github/workflows/download-images-status.yml
+++ b/.github/workflows/download-images-status.yml
@@ -66,6 +66,7 @@ jobs:
           ' "$PAGE" > tmp.md && mv tmp.md "$PAGE"
 
       - name: Create Pull Request
+        id: cpr
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/create-pull-request@v8
         with:
@@ -82,3 +83,16 @@ jobs:
           labels: |
             Needs review
           draft: false
+
+      - name: Approve and enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          # the Actions bot cannot approve its own PR, so approve with a
+          # maintainer PAT, then queue squash auto-merge (delete branch on merge)
+          GH_TOKEN="$APPROVE_TOKEN" gh pr review "$PR" --approve
+          gh pr merge "$PR" --squash --auto

--- a/.github/workflows/download-images-status.yml
+++ b/.github/workflows/download-images-status.yml
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           # the Actions bot cannot approve its own PR, so approve with a

--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -158,7 +158,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           # the Actions bot cannot approve its own PR, so approve with a

--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -136,6 +136,7 @@ jobs:
           cat block.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create Pull Request to documentation
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -151,3 +152,16 @@ jobs:
           labels: |
             Needs review
           draft: false
+
+      - name: Approve and enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          # the Actions bot cannot approve its own PR, so approve with a
+          # maintainer PAT, then queue squash auto-merge (delete branch on merge)
+          GH_TOKEN="$APPROVE_TOKEN" gh pr review "$PR" --approve
+          gh pr merge "$PR" --squash --auto


### PR DESCRIPTION
Follow-up to #1048 (which landed the `add-paths` fix). Makes the `Automatic` status update PRs merge hands-off.

`main` requires **1 approving review** and has **no required status checks**, so after opening each PR the workflow now:
- **approves** it with `secrets.ACCESS_TOKEN_ARMBIANWORKER` (the armbianworker bot — a separate identity, since the Actions bot can't approve its own PR), then
- queues **squash auto-merge** (`gh pr merge --squash --auto`), which lands once the review is satisfied; the branch auto-deletes.

Both steps are `continue-on-error`, so if the token is unavailable the PR just stays open for manual review. Applied to all four: build-machinery, apt, download-images, mirrors.

Reuses the existing armbianworker secret — no new secret needed.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1050"><kbd><br> Open WWW preview <br></kbd></a>