### PR TITLE
docs(status): add the Tested boards page (fleet test results)

### DIFF
--- a/docs/status/board-tests.md
+++ b/docs/status/board-tests.md
@@ -7,7 +7,7 @@ description: "Automated per-board test results from the Armbian autotests fleet 
 
 Every board in the Armbian test datacenter runs an automated pipeline — a nightly **upgrade**, a **reboot**, hardware **performance** and **DVFS** checks and a **network** throughput test — before being restored to the stable release. The table below is the **current status**: the most recent test of each board.
 
-The list is refreshed by the fleet test workflow in the [autotests repo](https://github.com/armbian/autotests): it reads the rolling [`test-results`](https://github.com/armbian/autotests/releases/tag/test-results) release and opens a pull request to update this table — the same mechanism used for the [datacenter boards](/status/boards/) and [Wi-Fi performance](/status/wifi-performance/) pages.
+The list is refreshed automatically by the Armbian autotests fleet: a scheduled job reads the fleet's rolling test results and opens a pull request to update this table — the same mechanism used for the [datacenter boards](/status/boards/) and [Wi-Fi performance](/status/wifi-performance/) pages.
 
 Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 

--- a/docs/status/board-tests.md
+++ b/docs/status/board-tests.md
@@ -1,0 +1,18 @@
+---
+title: Tested boards
+seo_title: "Armbian tested boards: automated fleet test results"
+description: "Automated per-board test results from the Armbian autotests fleet — upgrade, reboot, performance, DVFS and network checks across single-board computers."
+---
+# Tested boards
+
+Every board in the Armbian test datacenter runs an automated pipeline — a nightly **upgrade**, a **reboot**, hardware **performance** and **DVFS** checks and a **network** throughput test — before being restored to the stable release. The table below is the **current status**: the most recent test of each board.
+
+The list is refreshed by the fleet test workflow in the [autotests repo](https://github.com/armbian/autotests): it reads the rolling [`test-results`](https://github.com/armbian/autotests/releases/tag/test-results) release and opens a pull request to update this table — the same mechanism used for the [datacenter boards](/status/boards/) and [Wi-Fi performance](/status/wifi-performance/) pages.
+
+Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
+
+<!-- FLEET-START -->
+
+_No results published yet._
+
+<!-- FLEET-STOP -->

--- a/docs/status/index.md
+++ b/docs/status/index.md
@@ -25,9 +25,9 @@ refreshed by scheduled jobs, not written by hand.
 
     Measured throughput per board and wireless chip, from the autotest fleet.
 
-- :material-developer-board: **Tested boards** *(planned)*
+- :material-developer-board: **[Tested boards](board-tests.md)**
 
-    Functional test matrix — what boots, what passes, per board.
+    Per-board test results — upgrade, reboot, performance, DVFS and network — from the autotest fleet.
 
 - :material-database: **[Datacenter boards](boards.md)**
 

--- a/docs/status/index.md
+++ b/docs/status/index.md
@@ -58,10 +58,3 @@ refreshed by scheduled jobs, not written by hand.
     The build servers — CPU-thread capacity, memory, location and runner count.
 
 </div>
-
-!!! note "Prototype"
-
-    This is the first cut of the section. The **planned** entries above already
-    have generators (autotests, `armbian.github.io`, the apt report) that
-    currently write to CI job summaries; wiring them into pages here is the next
-    step.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -349,6 +349,7 @@ nav:
   - 'STATUS' :
         - 'Overview' : 'status/index.md'
         - 'Wi-Fi performance' : 'status/wifi-performance.md'
+        - 'Tested boards' : 'status/board-tests.md'
         - 'Datacenter boards' : 'status/boards.md'
         - 'Mirrors' : 'status/mirrors.md'
         - 'Download images' : 'status/download-images.md'


### PR DESCRIPTION
New **Tested boards** status page — the page the overview already listed as *(planned)*.

It surfaces the Armbian autotests **fleet test results**: per board, the overall verdict plus per-module pass/fail (**upgrade, reboot, performance, DVFS, network**), the tested **kernel**, and the **date**. The table shows the *current* status — each board's most recent test.

It's refreshed automatically from the fleet's rolling test results, injected between `<!-- FLEET-START/STOP -->` markers — the same mechanism as the [datacenter boards](https://docs.armbian.com/status/boards/) and [Wi-Fi performance](https://docs.armbian.com/status/wifi-performance/) pages. The generator + publish workflow land in a companion autotests PR; until that first runs, the page shows a placeholder between the markers.

Note: autotests is a **private** repo, so the page deliberately carries **no links to it** (they would 404 for public readers), and the generated table emits no `actions/runs` URLs.

Changes:
- `docs/status/board-tests.md` (new, with markers + legend)
- STATUS nav entry
- activated the "Tested boards" card on the status overview (was *(planned)*)

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1054"><kbd><br> Open WWW preview <br></kbd></a>