### PR TITLE
docs(status): reword Tested boards intro for per-board cards

### DIFF
--- a/docs/status/board-tests.md
+++ b/docs/status/board-tests.md
@@ -5,9 +5,9 @@ description: "Automated per-board test results from the Armbian autotests fleet 
 ---
 # Tested boards
 
-Every board in the Armbian test datacenter runs an automated pipeline — a nightly **upgrade**, a **reboot**, hardware **performance** and **DVFS** checks and a **network** throughput test — before being restored to the stable release. The table below is the **current status**: the most recent test of each board.
+Every board in the Armbian test datacenter runs an automated pipeline — a nightly **upgrade**, a **reboot**, hardware **performance** and **DVFS** checks and a **network** throughput test — before being restored to the stable release. Each board below is a **card** — collapsed to its name and pass/fail; expand it for the per-module results, timings and power. The set is the **current status**: the most recent test of every board.
 
-The list is refreshed automatically by the Armbian autotests fleet: a scheduled job reads the fleet's rolling test results and opens a pull request to update this table — the same mechanism used for the [datacenter boards](/status/boards/) and [Wi-Fi performance](/status/wifi-performance/) pages.
+The list is refreshed automatically by the Armbian autotests fleet: a scheduled job reads the fleet's rolling test results and opens a pull request to update this page — the same mechanism used for the [datacenter boards](/status/boards/) and [Wi-Fi performance](/status/wifi-performance/) pages.
 
 Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 


### PR DESCRIPTION
Companion to autotests #106: the fleet-results generator now emits a **collapsible card per board** (cleaned per-module detail + power) rather than a single status table. Reword the Tested boards intro to describe the cards (collapsed to name + pass/fail, expand for module results, timings and power). Content only; the FLEET markers are untouched.

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1056"><kbd><br> Open WWW preview <br></kbd></a>