### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -13,9 +13,9 @@ update the table — the same mechanism behind the
 
 <!-- BOARDS-START -->
 
-**75** boards — **30** operational, **45** broken.
+**77** boards — **35** operational, **42** broken.
 
-Reconcile made: 2026-08-28 16:59 UTC
+Reconcile made: 2026-08-28 17:31 UTC
 
 **Operational**
 
@@ -23,7 +23,9 @@ Reconcile made: 2026-08-28 16:59 UTC
 |:--|:--|:--|--:|:--|
 | Arduino UNO Q 01 | 10.0.20.131 | local | Wi-Fi 5 | Zyxel NWA130BE |
 | Banana Pi CM4IO 01 | 10.0.50.12 | local | 1 GbE | Netgear S3300 (43) |
+| Banana Pi M2 Ultra 01 | 10.0.50.83 | local | 1 GbE | TP-Link SG3428X (13) |
 | Banana Pi M2Pro 01 | 10.0.50.80 | local | 1 GbE | Netgear S3300 (47) |
+| Banana Pi M5 01 | 10.0.50.63 | local | 1 GbE | Netgear GS348 (19) |
 | Banana Pi Pro 01 | 10.0.50.43 | local | 100 MbE | Netgear GS348 (8) |
 | Cubie A5E 01 | 10.0.50.72 | local | 1 GbE | Netgear S3300 (4) |
 | Cubietruck 01 | 10.0.50.82 | local | 1 GbE | TP-Link SG3428X (14) |
@@ -39,6 +41,7 @@ Reconcile made: 2026-08-28 16:59 UTC
 | Odroid C4 01 | 10.0.50.26 | local | 1 GbE | TP-Link SG3428X (10) |
 | Odroid M1 01 | 10.0.50.50 | local | 1 GbE | Netgear S3300 (38) |
 | Orange Pi One+ 01 | 10.0.50.37 | local | 1 GbE | TP-Link SG3428X (18) |
+| Orange Pi PC2 01 | 10.0.50.58 | local | 1 GbE | TP-Link SG3428X (22) |
 | Orange Pi Prime 01 | 10.0.50.16 | local | 1 GbE | Netgear S3300 (23) |
 | Orange Pi R1 01 | 10.0.50.25 | local | Wi-Fi 4 | Zyxel NWA130BE |
 | Orange Pi Zero2 01 | 10.0.50.74 | local | 1 GbE | Netgear S3300 (45) |
@@ -47,7 +50,9 @@ Reconcile made: 2026-08-28 16:59 UTC
 | Radxa ZERO 3 01 | 10.0.20.185 | local | Wi-Fi 6 | Zyxel NWA130BE |
 | Raspberry Pi 01 | 10.0.50.10 | local | 1 GbE | Netgear S3300 (1) |
 | ROCK 2F 01 | 10.0.20.164 | local | Wi-Fi 6 | Zyxel NWA130BE |
+| Rock 5B 03 | 10.0.50.186 | local | 2.5 GbE | — |
 | Rock 5T 01 | 10.0.50.15 | local | 2.5 GbE | TP-Link SG3218XP-M2 (12) |
+| Rockpi E 01 | 10.0.50.66 | local | 1 GbE | TP-Link SG3428X (16) |
 | SpacemiT K3 Pico-ITX 01 | 10.0.50.44 | local | 1 GbE | Netgear S3300 (52) |
 | Tanix TX6 01 | 10.0.50.21 | local | 100 MbE | Netgear GS348 (46) |
 | UEFI arm64 01 | 10.0.50.45 | local | 10 GbE | Netgear XS712T (6) |
@@ -57,11 +62,9 @@ Reconcile made: 2026-08-28 16:59 UTC
 | Board | IP address | Boot | Link | Switch |
 |:--|:--|:--|--:|:--|
 | A64 OLinuXino 01 | 10.0.20.150 | local | 1 GbE | — |
-| Banana Pi M2 Ultra 01 | 10.0.50.83 | local | 1 GbE | TP-Link SG3428X (13) |
-| Banana Pi M5 01 | 10.0.50.63 | local | 1 GbE | Netgear GS348 (19) |
 | BananaPi BPI-F3 01 | 10.0.50.78 | local | 1 GbE | Netgear S3300 (46) |
 | BigTreeTech CB1 01 | 10.0.50.62 | local | Wi-Fi 4 | Zyxel NWA130BE |
-| Clearfog Pro 01 | 10.0.50.42 | local | 1 GbE | TP-Link SG3428X (12) |
+| Clearfog Pro 01 | 10.0.50.61 | local | 1 GbE | TP-Link SG3428X (12) |
 | Inovato Quadra 01 | 10.0.50.36 | local | 100 MbE | Netgear GS348 (17) |
 | Khadas VIM1 01 | 10.0.50.71 | local | 100 MbE | Netgear GS348 (3) |
 | Khadas VIM3 01 | 10.0.50.38 | local | 1 GbE | Netgear GS348 (36) |
@@ -80,12 +83,12 @@ Reconcile made: 2026-08-28 16:59 UTC
 | NanoPi R6S 01 | 10.0.50.40 | local | 1 GbE | Netgear S3300 (44) |
 | Odroid C2 01 | 10.0.50.87 | local | 1 GbE | Netgear GS348 (7) |
 | Odroid N2 01 | 10.0.60.10 | local | 1 GbE | Netgear S3300 (14) |
-| Odroid XU4 01 | 10.0.50.51 | local | 1 GbE | Netgear S3300 (19) |
+| Odroid XU4 01 | 10.0.50.68 | local | 1 GbE | Netgear S3300 (19) |
 | Orange Pi 3 01 | 10.0.50.57 | local | 1 GbE | Netgear S3300 (31) |
 | Orange Pi 5 01 | 10.0.50.39 | local | 1 GbE | TP-Link SG3218XP-M2 (5) |
+| Orange Pi 5 Plus 01 | 10.0.50.55 | local | 1 GbE | Netgear S3300 (8) |
 | Orange Pi 5 Plus 02 | 10.0.50.33 | local | 2.5 GbE | — |
 | Orange Pi Lite 2 01 | 10.0.20.125 | local | Wi-Fi 5 | Zyxel NWA130BE |
-| Orange Pi PC2 01 | 10.0.50.58 | local | 1 GbE | TP-Link SG3428X (22) |
 | Orange Pi Win 01 | 10.0.50.24 | local | 1 GbE | Netgear S3300 (13) |
 | Orange Pi Zero 02 | 10.0.50.46 | local | Wi-Fi 4 | Zyxel NWA130BE |
 | Orange Pi Zero Plus 01 | 10.0.50.54 | local | 1 GbE | TP-Link SG3428X (20) |
@@ -93,9 +96,8 @@ Reconcile made: 2026-08-28 16:59 UTC
 | Raspberry Pi 02 | 10.0.50.22 | local | 100 MbE | Netgear GS348 (21) |
 | Rock 5B 01 | 10.0.50.69 | local | 2.5 GbE | Netgear XS508M (6) |
 | Rock 5B 02 | 10.0.50.17 | local | 2.5 GbE | Netgear XS508M (5) |
-| Rock 5B Plus 01 | 10.0.50.41 | local | 2.5 GbE | Netgear XS508M (4) |
+| Rock 5B Plus 01 | 10.0.50.47 | local | 2.5 GbE | Netgear XS508M (4) |
 | Rockpi 4B+ 01 | 10.0.50.64 | local | Wi-Fi 5 | Zyxel NWA130BE |
-| Rockpi E 01 | 10.0.50.66 | local | 1 GbE | TP-Link SG3428X (16) |
 | Tinker Board 01 | 10.0.50.29 | local | 1 GbE | Netgear S3300 (15) |
 | Tinker Board 2 01 | 10.0.50.23 | local | 1 GbE | TP-Link SG3428X (15) |
 | Udoo 01 | 10.0.50.13 | local | 1 GbE | Netgear S3300 (37) |


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1073"><kbd><br> Open WWW preview <br></kbd></a>