### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -13,9 +13,9 @@ update the table — the same mechanism behind the
 
 <!-- BOARDS-START -->
 
-**76** boards — **37** operational, **39** broken.
+**76** boards — **38** operational, **38** broken.
 
-Reconcile made: 2026-08-28 17:58 UTC
+Reconcile made: 2026-08-28 18:15 UTC
 
 **Operational**
 
@@ -37,10 +37,10 @@ Reconcile made: 2026-08-28 17:58 UTC
 | NanoPi M4V2 01 | 10.0.50.49 | local | 1 GbE | Aruba 2540 (5) |
 | NanoPi R1 01 | 10.0.50.59 | local | 1 GbE | Netgear GS348 (14) |
 | NanoPi R76S 01 | 10.0.50.77 | local | 2.5 GbE | Netgear XS508M (7) |
-| Odroid C1 01 | 10.0.50.27 | local | 1 GbE | Netgear GS348 (28) |
 | Odroid C4 01 | 10.0.50.26 | local | 1 GbE | TP-Link SG3428X (10) |
 | Odroid M1 01 | 10.0.50.50 | local | 1 GbE | Netgear S3300 (38) |
 | Odroid XU4 01 | 10.0.50.68 | local | 1 GbE | Netgear S3300 (19) |
+| Orange Pi 3 01 | 10.0.50.41 | local | 1 GbE | Netgear S3300 (31) |
 | Orange Pi 5 Plus 01 | 10.0.50.55 | local | 1 GbE | Netgear S3300 (8) |
 | Orange Pi One+ 01 | 10.0.50.37 | local | 1 GbE | TP-Link SG3428X (18) |
 | Orange Pi PC2 01 | 10.0.50.58 | local | 1 GbE | TP-Link SG3428X (22) |
@@ -52,6 +52,7 @@ Reconcile made: 2026-08-28 17:58 UTC
 | Radxa ZERO 3 01 | 10.0.20.185 | local | Wi-Fi 6 | Zyxel NWA130BE |
 | Raspberry Pi 01 | 10.0.50.10 | local | 1 GbE | Netgear S3300 (1) |
 | ROCK 2F 01 | 10.0.20.164 | local | Wi-Fi 6 | Zyxel NWA130BE |
+| Rock 5B 02 | 10.0.50.32 | local | 2.5 GbE | Netgear XS508M (5) |
 | Rock 5B Plus 01 | 10.0.50.47 | local | 2.5 GbE | Netgear XS508M (4) |
 | Rock 5T 01 | 10.0.50.15 | local | 2.5 GbE | TP-Link SG3218XP-M2 (12) |
 | Rockpi E 01 | 10.0.50.66 | local | 1 GbE | TP-Link SG3428X (16) |
@@ -82,9 +83,9 @@ Reconcile made: 2026-08-28 17:58 UTC
 | NanoPi Neo 3 01 | 10.0.50.20 | local | 1 GbE | TP-Link SG3428X (17) |
 | Nanopi R2S 01 | 10.0.50.65 | local | 1 GbE | Netgear S3300 (12) |
 | NanoPi R6S 01 | 10.0.50.40 | local | 1 GbE | Netgear S3300 (44) |
+| Odroid C1 01 | 10.0.50.27 | local | 1 GbE | Netgear GS348 (28) |
 | Odroid C2 01 | 10.0.50.87 | local | 1 GbE | Netgear GS348 (7) |
 | Odroid N2 01 | 10.0.60.10 | local | 1 GbE | Netgear S3300 (14) |
-| Orange Pi 3 01 | 10.0.50.41 | local | 1 GbE | Netgear S3300 (31) |
 | Orange Pi 5 01 | 10.0.50.39 | local | 1 GbE | TP-Link SG3218XP-M2 (5) |
 | Orange Pi 5 Plus 02 | 10.0.50.33 | local | 2.5 GbE | — |
 | Orange Pi Lite 2 01 | 10.0.20.125 | local | Wi-Fi 5 | Zyxel NWA130BE |
@@ -92,9 +93,8 @@ Reconcile made: 2026-08-28 17:58 UTC
 | Orange Pi Zero 02 | 10.0.50.46 | local | Wi-Fi 4 | Zyxel NWA130BE |
 | Orange Pi Zero Plus 01 | 10.0.50.54 | local | 1 GbE | TP-Link SG3428X (20) |
 | Pine H64 01 | 10.0.50.34 | local | 1 GbE | TP-Link SG3428X (9) |
-| Raspberry Pi 02 | 10.0.50.22 | local | 100 MbE | Netgear GS348 (21) |
+| Raspberry Pi 02 | 10.0.50.17 | local | 100 MbE | Netgear GS348 (21) |
 | Rock 5B 01 | 10.0.50.69 | local | 2.5 GbE | Netgear XS508M (6) |
-| Rock 5B 02 | 10.0.50.32 | local | 2.5 GbE | Netgear XS508M (5) |
 | Rock 5B 03 | 10.0.50.186 | local | 2.5 GbE | — |
 | Rockpi 4B+ 01 | 10.0.50.64 | local | Wi-Fi 5 | Zyxel NWA130BE |
 | Tinker Board 01 | 10.0.50.29 | local | 1 GbE | Netgear S3300 (15) |


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1076"><kbd><br> Open WWW preview <br></kbd></a>