### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -15,7 +15,7 @@ update the table — the same mechanism behind the
 
 **75** boards — **39** operational, **36** broken.
 
-Reconcile made: 2026-08-28 18:45 UTC
+Reconcile made: 2026-08-29 04:21 UTC
 
 **Operational**
 


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1080"><kbd><br> Open WWW preview <br></kbd></a>