### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -13,16 +13,15 @@ update the table — the same mechanism behind the
 
 <!-- BOARDS-START -->
 
-**76** boards — **35** operational, **41** broken.
+**76** boards — **36** operational, **40** broken.
 
-Reconcile made: 2026-08-29 06:12 UTC
+Reconcile made: 2026-08-29 06:22 UTC
 
 **Operational**
 
 | Board | IP address | Boot | Link | Switch |
 |:--|:--|:--|--:|:--|
 | Arduino UNO Q 01 | 10.0.20.131 | local | Wi-Fi 5 | Zyxel NWA130BE |
-| Banana Pi CM4IO 02 | 10.0.50.51 | local | 1 GbE | — |
 | Banana Pi M2 Ultra 01 | 10.0.50.83 | local | 1 GbE | TP-Link SG3428X (13) |
 | Banana Pi M2Pro 01 | 10.0.50.80 | local | 1 GbE | Netgear S3300 (47) |
 | Banana Pi M5 01 | 10.0.50.63 | local | 1 GbE | Netgear GS348 (19) |
@@ -37,6 +36,7 @@ Reconcile made: 2026-08-29 06:12 UTC
 | NanoPi M4V2 01 | 10.0.50.49 | local | 1 GbE | Aruba 2540 (5) |
 | NanoPi R1 01 | 10.0.50.59 | local | 1 GbE | Netgear GS348 (14) |
 | NanoPi R76S 01 | 10.0.50.77 | local | 2.5 GbE | Netgear XS508M (7) |
+| Odroid C2 01 | 10.0.50.22 | local | 1 GbE | Netgear GS348 (7) |
 | Odroid C4 01 | 10.0.50.26 | local | 1 GbE | TP-Link SG3428X (10) |
 | Odroid M1 01 | 10.0.50.50 | local | 1 GbE | Netgear S3300 (38) |
 | Odroid XU4 01 | 10.0.50.68 | local | 1 GbE | Netgear S3300 (19) |
@@ -55,6 +55,7 @@ Reconcile made: 2026-08-29 06:12 UTC
 | Rock 5T 01 | 10.0.50.15 | local | 2.5 GbE | TP-Link SG3218XP-M2 (12) |
 | Rockpi E 01 | 10.0.50.66 | local | 1 GbE | TP-Link SG3428X (16) |
 | SpacemiT K3 Pico-ITX 01 | 10.0.50.44 | local | 1 GbE | Netgear S3300 (52) |
+| Tinker Board 01 | 10.0.50.33 | local | 1 GbE | Netgear S3300 (15) |
 | UEFI arm64 01 | 10.0.50.45 | local | 10 GbE | Netgear XS712T (6) |
 
 **Broken**
@@ -62,8 +63,9 @@ Reconcile made: 2026-08-29 06:12 UTC
 | Board | IP address | Boot | Link | Switch |
 |:--|:--|:--|--:|:--|
 | A64 OLinuXino 01 | 10.0.20.150 | local | 1 GbE | — |
-| Banana Pi CM4IO 01 | 10.0.50.12 | local | 1 GbE | Netgear S3300 (43) |
-| BananaPi BPI-F3 01 | 10.0.50.78 | local | 1 GbE | Netgear S3300 (46) |
+| Banana Pi CM4IO 01 | 10.0.50.29 | local | 1 GbE | Netgear S3300 (43) |
+| Banana Pi CM4IO 02 | 10.0.50.51 | local | 1 GbE | — |
+| BananaPi BPI-F3 01 | 10.0.50.57 | local | 1 GbE | Netgear S3300 (46) |
 | BigTreeTech CB1 01 | 10.0.50.62 | local | Wi-Fi 4 | Zyxel NWA130BE |
 | Inovato Quadra 01 | 10.0.50.36 | local | 100 MbE | Netgear GS348 (17) |
 | Khadas VIM1 01 | 10.0.50.71 | local | 100 MbE | Netgear GS348 (3) |
@@ -82,7 +84,6 @@ Reconcile made: 2026-08-29 06:12 UTC
 | Nanopi R2S 01 | 10.0.50.65 | local | 1 GbE | Netgear S3300 (12) |
 | NanoPi R6S 01 | 10.0.50.40 | local | 1 GbE | Netgear S3300 (44) |
 | Odroid C1 01 | 10.0.50.27 | local | 1 GbE | Netgear GS348 (28) |
-| Odroid C2 01 | 10.0.50.22 | local | 1 GbE | Netgear GS348 (7) |
 | Odroid N2 01 | 10.0.60.10 | local | 1 GbE | Netgear S3300 (14) |
 | Orange Pi 3 01 | 10.0.50.41 | local | 1 GbE | Netgear S3300 (31) |
 | Orange Pi 5 01 | 10.0.50.39 | local | 1 GbE | TP-Link SG3218XP-M2 (5) |
@@ -97,7 +98,6 @@ Reconcile made: 2026-08-29 06:12 UTC
 | Rock 5B Plus 01 | 10.0.50.47 | local | 2.5 GbE | Netgear XS508M (4) |
 | Rockpi 4B+ 01 | 10.0.50.64 | local | Wi-Fi 5 | Zyxel NWA130BE |
 | Tanix TX6 01 | 10.0.50.21 | local | 100 MbE | Netgear GS348 (46) |
-| Tinker Board 01 | 10.0.50.33 | local | 1 GbE | Netgear S3300 (15) |
 | Tinker Board 2 01 | 10.0.50.23 | local | 1 GbE | TP-Link SG3428X (15) |
 | Udoo 01 | 10.0.50.13 | local | 1 GbE | Netgear S3300 (37) |
 | UEFI x86 01 | 10.0.50.53 | local | 1 GbE | Netgear S3300 (2) |


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1082"><kbd><br> Open WWW preview <br></kbd></a>