### PR TITLE
`Automatic` fleet test results

### DIFF
--- a/docs/status/board-tests.md
+++ b/docs/status/board-tests.md
@@ -13,46 +13,31 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 <!-- FLEET-START -->
 
-**86** boards — **47** passed, **39** failed. Each card is the board's most recent test.
+**87** boards — **48** passed, **39** failed. Each card is the board's most recent test.
 
 ??? success "Arduino UNO Q 01 — pass"
 
-    `arduino-uno-q` · **inplace** · image `26.11.0-trunk.6` · 6 ✅ · 1 ❌ · 1 ⏭️
+    `arduino-uno-q` · **inplace** · image `26.11.0-trunk.27` · 7 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 23.8 s | — |
-    | reboot | ✅ | 50.7 s | warm · up 34 s |
-    | hw-performance | ✅ | 24.7 s | AES 940 · mem 5100 · disk W 169 / R 222 MB/s · 45 °C · 2016 MHz |
-    | dvfs | ✅ | 32.1 s | schedutil · 300–2016 MHz (peak 2016) |
-    | network-iperf | ❌ | 375.2 s | usb0 ↑0/↓0 (1GE) · wlan0 ↑22/↓19 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 27.5 s | stable |
-    | reboot | ✅ | 50.8 s | warm · up 34 s |
-    | store-versions | ✅ | 6.8 s | 26.11.0-trunk.6 · 7.1.8-edge-qrb2210 |
+    | upgrade | ✅ | 158.6 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 50.3 s | warm · up 33 s |
+    | hw-performance | ✅ | 24.4 s | AES 934 · mem 5100 · disk W 174 / R 245 MB/s · 44.6 °C · 2016 MHz |
+    | dvfs | ✅ | 32.0 s | schedutil · 300–2016 MHz (peak 2016) |
+    | network-iperf | ❌ | 326.9 s | usb0 ↑0/↓0 (1GE) · wlan0 ↑17/↓20 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 102.2 s | stable |
+    | reboot | ✅ | 49.8 s | warm · up 33 s |
+    | store-versions | ✅ | 6.9 s | 26.11.0-trunk.27 · 7.1.8-edge-qrb2210 |
 
-??? success "Banana Pi CM4IO 01 — pass"
+??? failure "Banana Pi CM4IO 01 — fail"
 
-    `bananapicm4io` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
-
-    | Module | Status | Time | Detail |
-    |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 15.5 s | — |
-    | reboot | ✅ | 52.1 s | power-cycle · up 28 s |
-    | hw-performance | ✅ | 26.8 s | AES 1364 · mem 6200 · disk W 13 / R 22 MB/s · 62.3 °C · 2016 MHz |
-    | dvfs | ✅ | 15.8 s | performance · 1000–2016 MHz (peak 2400) |
-    | network-iperf | ✅ | 248.0 s | end0 ↑937/↓941 (1GE) · wlan0 ↑32/↓33 (Wi-Fi 5) · wlx00e032c00694 ↑101/↓172 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 15.7 s | stable |
-    | reboot | ✅ | 47.3 s | power-cycle · up 24 s |
-    | store-versions | ✅ | 3.4 s | 26.8.3 · 6.18.44-current-meson64 |
-
-??? failure "Banana Pi M2 Ultra 01 — fail"
-
-    `bananapim2ultra` · **inplace** · image `26.11.0-trunk.19` · 0 ✅ · 1 ❌ · 7 ⏭️
+    `bananapicm4io` · **inplace** · image `26.11.0-trunk.27` · 1 ✅ · 1 ❌ · 6 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 17.8 s | — |
-    | reboot | ❌ | 200.1 s | warm |
+    | upgrade | ✅ | 111.4 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ❌ | 205.2 s | power-cycle |
     | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
     | dvfs | ⏭️ | 0.0 s | — |
     | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
@@ -60,50 +45,58 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     | reboot | ⏭️ | 0.0 s | reboot |
     | store-versions | ⏭️ | 0.0 s | — |
 
-??? success "Banana Pi M2Pro 01 — pass"
+??? failure "Banana Pi M2 Ultra 01 — fail"
 
-    `bananapim2pro` · **inplace** · image `26.11.0-trunk.19` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `bananapim2ultra` · **inplace** · image `26.11.0-trunk.19` · 0 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 18.2 s | — |
-    | reboot | ✅ | 43.6 s | power-cycle · up 18 s |
-    | hw-performance | ✅ | 20.6 s | AES 978 · mem 5300 · disk W 43 / R 158 MB/s · 53.1 °C · 2100 MHz |
-    | dvfs | ✅ | 19.6 s | ondemand · 1000–2100 MHz (peak 2100) |
-    | network-iperf | ✅ | 255.7 s | end0 ↑940/↓941 (1GE) · wlx60fb00480eb0 ↑139/↓87 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 20.5 s | stable |
-    | reboot | ✅ | 47.5 s | power-cycle · up 18 s |
-    | store-versions | ✅ | 5.1 s | 26.11.0-trunk.19 · 6.18.44-current-meson64 |
+    | reachable | ❌ | 0.0 s | ip=10.0.50.83 · reachable=False · port=22 |
+
+??? success "Banana Pi M2Pro 01 — pass"
+
+    `bananapim2pro` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
+
+    | Module | Status | Time | Detail |
+    |:--|:--:|--:|:--|
+    | upgrade | ✅ | 118.2 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 46.1 s | power-cycle · up 22 s |
+    | hw-performance | ✅ | 20.0 s | AES 980 · mem 5300 · disk W 42 / R 152 MB/s · 53.1 °C · 2100 MHz |
+    | dvfs | ✅ | 20.0 s | ondemand · 1000–2100 MHz (peak 2100) |
+    | network-iperf | ✅ | 257.3 s | end0 ↑940/↓941 (1GE) · wlx60fb00480eb0 ↑192/↓211 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 80.5 s | stable |
+    | reboot | ✅ | 43.0 s | power-cycle · up 18 s |
+    | store-versions | ✅ | 4.5 s | 26.11.0-trunk.27 · 6.18.44-current-meson64 |
 
 ??? success "Banana Pi M5 01 — pass"
 
-    `bananapim5` · **inplace** · image `26.8.1` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `bananapim5` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 15.5 s | — |
-    | reboot | ✅ | 173.0 s | warm · up 155 s |
-    | hw-performance | ✅ | 38.2 s | AES 980 · mem 5300 · disk W 11 / R 15 MB/s · 56.2 °C · 2100 MHz |
-    | dvfs | ✅ | 19.7 s | ondemand · 1000–2100 MHz (peak 2100) |
-    | network-iperf | ✅ | 274.1 s | end0 ↑941/↓941 (1GE) · wlx000f13960190 ↑1/↓5 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 26.4 s | stable |
-    | reboot | ✅ | 166.0 s | warm · up 149 s |
-    | store-versions | ✅ | 5.3 s | 26.8.3 · 6.18.44-current-meson64 |
+    | upgrade | ✅ | 185.6 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 171.8 s | warm · up 155 s |
+    | hw-performance | ✅ | 37.6 s | AES 979 · mem 5300 · disk W 10 / R 15 MB/s · 54.7 °C · 2100 MHz |
+    | dvfs | ✅ | 20.2 s | ondemand · 1000–2100 MHz (peak 2100) |
+    | network-iperf | ✅ | 108.2 s | end0 ↑940/↓941 (1GE) · wlx000f13960190 ↑1/↓11 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 144.8 s | stable |
+    | reboot | ✅ | 167.1 s | warm · up 150 s |
+    | store-versions | ✅ | 4.8 s | 26.11.0-trunk.27 · 6.18.44-current-meson64 |
 
 ??? success "Banana Pi Pro 01 — pass"
 
-    `bananapipro` · **inplace** · image `26.11.0-trunk.19` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `bananapipro` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 51.3 s | — |
-    | reboot | ✅ | 64.6 s | warm · up 44 s |
-    | hw-performance | ✅ | 51.7 s | AES 19 · mem 1700 · disk W 21 / R 22 MB/s · 50.9 °C · 960 MHz |
-    | dvfs | ✅ | 47.1 s | ondemand · 528–960 MHz (peak 960) |
-    | network-iperf | ✅ | 304.6 s | end0 ↑94/↓94 (10/100ME) · wlan0 ↑16/↓10 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 58.9 s | stable |
-    | reboot | ✅ | 62.8 s | warm · up 43 s |
-    | store-versions | ✅ | 11.2 s | 26.11.0-trunk.19 · 6.18.44-current-sunxi |
+    | upgrade | ✅ | 278.8 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 65.1 s | warm · up 44 s |
+    | hw-performance | ✅ | 49.6 s | AES 19 · mem 1700 · disk W 19 / R 22 MB/s · 50.7 °C · 960 MHz |
+    | dvfs | ✅ | 46.3 s | ondemand · 528–960 MHz (peak 960) |
+    | network-iperf | ✅ | 206.4 s | end0 ↑94/↓94 (10/100ME) · wlan0 ↑8/↓17 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 191.7 s | stable |
+    | reboot | ✅ | 64.2 s | warm · up 43 s |
+    | store-versions | ✅ | 11.0 s | 26.11.0-trunk.27 · 6.18.44-current-sunxi |
 
 ??? failure "BananaPi BPI-F3 01 — fail"
 
@@ -147,35 +140,50 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Cubie A5E 01 — pass"
 
-    `radxa-cubie-a5e` · **inplace** · image `26.11.0-trunk.19` · 6 ✅ · 0 ❌ · 2 ⏭️
+    `radxa-cubie-a5e` · **inplace** · image `26.11.0-trunk.27` · 7 ✅ · 0 ❌ · 1 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 28.8 s | — |
-    | reboot | ✅ | 139.8 s | power-cycle · up 113 s |
-    | hw-performance | ✅ | 46.4 s | AES 358 · mem 2000 · disk W 11 / R 23 MB/s · 69.2 °C · None MHz |
+    | upgrade | ✅ | 189.9 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 141.2 s | power-cycle · up 112 s |
+    | hw-performance | ✅ | 46.8 s | AES 358 · mem 2000 · disk W 10 / R 23 MB/s · 67.1 °C · None MHz |
     | dvfs | ➖ | 2.6 s | — |
-    | network-iperf | ✅ | 205.2 s | end0 ↑910/↓941 (1GE) · end1 ↑940/↓940 (1GE) Mbps |
-    | restore-stable | ✅ | 34.1 s | stable |
-    | reboot | ✅ | 141.2 s | power-cycle · up 110 s |
-    | store-versions | ✅ | 5.5 s | 26.11.0-trunk.19 · 6.18.44-current-sunxi64 |
+    | network-iperf | ✅ | 172.9 s | end0 ↑916/↓938 (1GE) · end1 ↑941/↓940 (1GE) Mbps |
+    | restore-stable | ✅ | 130.6 s | stable |
+    | reboot | ✅ | 139.9 s | power-cycle · up 112 s |
+    | store-versions | ✅ | 5.5 s | 26.11.0-trunk.27 · 6.18.44-current-sunxi64 |
 
-    **Power** — idle 2.40 W · avg 4.18 W · peak 5.50 W · 495 samples
+    **Power** — idle 1.00 W · avg 4.17 W · peak 5.20 W · 688 samples
 
 ??? success "Cubietruck 01 — pass"
 
-    `cubietruck` · **inplace** · image `26.11.0-trunk.19` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `cubietruck` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 50.8 s | — |
-    | reboot | ✅ | 63.4 s | warm · up 43 s |
-    | hw-performance | ✅ | 58.7 s | AES 18 · mem 1600 · disk W 19 / R 21 MB/s · 47.6 °C · 960 MHz |
-    | dvfs | ✅ | 55.8 s | ondemand · 528–960 MHz (peak 960) |
-    | network-iperf | ✅ | 517.6 s | end0 ↑715/↓748 (1GE) · wlan0 ↑20/↓20 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 56.7 s | stable |
-    | reboot | ✅ | 63.1 s | warm · up 43 s |
-    | store-versions | ✅ | 12.3 s | 26.11.0-trunk.19 · 6.18.44-current-sunxi |
+    | upgrade | ✅ | 285.2 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 65.4 s | warm · up 44 s |
+    | hw-performance | ✅ | 59.5 s | AES 19 · mem 1600 · disk W 15 / R 22 MB/s · 46.4 °C · 960 MHz |
+    | dvfs | ✅ | 55.7 s | ondemand · 528–960 MHz (peak 960) |
+    | network-iperf | ✅ | 264.9 s | end0 ↑722/↓732 (1GE) · wlan0 ↑12/↓26 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 190.8 s | stable |
+    | reboot | ✅ | 65.7 s | warm · up 45 s |
+    | store-versions | ✅ | 12.2 s | 26.11.0-trunk.27 · 6.18.44-current-sunxi |
+
+??? success "Cubox i2eX/i4 01 — pass"
+
+    `radxa-dragon-q6a` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
+
+    | Module | Status | Time | Detail |
+    |:--|:--:|--:|:--|
+    | upgrade | ✅ | 308.5 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 49.8 s | warm · up 30 s |
+    | hw-performance | ✅ | 46.7 s | AES 26 · mem 709 · disk W 19 / R 20 MB/s · 54.3 °C · 996 MHz |
+    | dvfs | ✅ | 39.6 s | ondemand · 396–996 MHz (peak 996) |
+    | network-iperf | ✅ | 231.7 s | end0 ↑392/↓586 (1GE) · wlan0 ↑19/↓20 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 233.4 s | stable |
+    | reboot | ✅ | 50.7 s | warm · up 30 s |
+    | store-versions | ✅ | 8.6 s | 26.11.0-trunk.27 · 6.18.44-current-imx6 |
 
 ??? success "Espressobin 01 — pass"
 
@@ -185,27 +193,27 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 41.0 s | AES 371 · mem 2000 · disk W 21 / R 127 MB/s · None °C · 800 MHz |
-    | dvfs | ✅ | 33.6 s | ondemand · 200–800 MHz (peak 800) |
-    | network-iperf | ✅ | 70.0 s | lan0 ↑924/↓756 (1GE) Mbps |
+    | hw-performance | ✅ | 46.7 s | AES 371 · mem 2000 · disk W 22 / R 83 MB/s · None °C · 800 MHz |
+    | dvfs | ✅ | 33.8 s | ondemand · 200–800 MHz (peak 800) |
+    | network-iperf | ✅ | 44.1 s | lan0 ↑932/↓746 (1GE) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 7.3 s | 26.8.3 · 6.18.42-current-mvebu64 |
+    | store-versions | ✅ | 7.9 s | 26.8.3 · 6.18.42-current-mvebu64 |
 
 ??? success "Helios4 01 — pass"
 
-    `helios4` · **inplace** · image `26.8.3` · 6 ✅ · 0 ❌ · 2 ⏭️
+    `helios4` · **inplace** · image `26.11.0-trunk.27` · 7 ✅ · 0 ❌ · 1 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 23.4 s | — |
-    | reboot | ✅ | 36.7 s | warm · up 19 s |
-    | hw-performance | ✅ | 41.5 s | AES 44 · mem 3700 · disk W 20 / R 23 MB/s · 57 °C · None MHz |
+    | upgrade | ✅ | 124.3 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 37.0 s | warm · up 19 s |
+    | hw-performance | ✅ | 41.8 s | AES 43 · mem 3700 · disk W 21 / R 23 MB/s · 56.1 °C · None MHz |
     | dvfs | ➖ | 2.8 s | — |
-    | network-iperf | ✅ | 179.1 s | end1 ↑941/↓941 (1GE) · wlx1cbfce1f85a5 ↑235/↓81 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 23.3 s | stable |
-    | reboot | ✅ | 37.4 s | warm · up 19 s |
-    | store-versions | ✅ | 5.8 s | 26.8.3 · 6.6.151-current-mvebu |
+    | network-iperf | ✅ | 311.3 s | end1 ↑941/↓941 (1GE) · wlx1cbfce1f85a5 ↑189/↓236 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 87.0 s | stable |
+    | reboot | ✅ | 39.8 s | warm · up 22 s |
+    | store-versions | ✅ | 5.7 s | 26.11.0-trunk.27 · 6.6.151-current-mvebu |
 
 ??? failure "Inovato Quadra 01 — fail"
 
@@ -239,18 +247,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Khadas VIM2 01 — pass"
 
-    `khadas-vim2` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `khadas-vim2` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 22.1 s | — |
-    | reboot | ✅ | 36.7 s | warm · up 18 s |
-    | hw-performance | ✅ | 23.9 s | AES 658 · mem 3500 · disk W 42 / R 151 MB/s · 54 °C · 1512 MHz |
+    | upgrade | ✅ | 189.8 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 36.5 s | warm · up 17 s |
+    | hw-performance | ✅ | 23.7 s | AES 655 · mem 3500 · disk W 42 / R 145 MB/s · 56 °C · 1512 MHz |
     | dvfs | ✅ | 25.2 s | ondemand · 500–1512 MHz (peak 1512) |
-    | network-iperf | ✅ | 255.9 s | eth0 ↑939/↓941 (1GE) · wlan0 ↑76/↓84 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 32.6 s | stable |
-    | reboot | ✅ | 35.4 s | warm · up 18 s |
-    | store-versions | ✅ | 5.4 s | 26.8.3 · 6.18.44-current-meson64 |
+    | network-iperf | ✅ | 98.8 s | eth0 ↑940/↓941 (1GE) · wlan0 ↑73/↓92 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 127.9 s | stable |
+    | reboot | ✅ | 35.3 s | warm · up 17 s |
+    | store-versions | ✅ | 5.4 s | 26.11.0-trunk.27 · 6.18.44-current-meson64 |
 
 ??? failure "Khadas VIM3 01 — fail"
 
@@ -269,18 +277,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Le potato 01 — pass"
 
-    `lepotato` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `lepotato` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 22.1 s | — |
-    | reboot | ✅ | 42.8 s | warm · up 26 s |
-    | hw-performance | ✅ | 31.9 s | AES 659 · mem 3600 · disk W 16 / R 2 MB/s · 50 °C · 1512 MHz |
-    | dvfs | ✅ | 22.8 s | ondemand · 500–1512 MHz (peak 1512) |
-    | network-iperf | ✅ | 173.2 s | end0 ↑94/↓94 (10/100ME) Mbps |
-    | restore-stable | ✅ | 31.6 s | stable |
-    | reboot | ✅ | 38.4 s | warm · up 22 s |
-    | store-versions | ✅ | 4.9 s | 26.8.3 · 6.18.44-current-meson64 |
+    | upgrade | ✅ | 205.4 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 43.4 s | warm · up 27 s |
+    | hw-performance | ✅ | 32.0 s | AES 656 · mem 3500 · disk W 16 / R 2 MB/s · 50 °C · 1512 MHz |
+    | dvfs | ✅ | 22.9 s | ondemand · 500–1512 MHz (peak 1512) |
+    | network-iperf | ✅ | 111.5 s | end0 ↑94/↓94 (10/100ME) Mbps |
+    | restore-stable | ✅ | 150.2 s | stable |
+    | reboot | ✅ | 41.0 s | warm · up 24 s |
+    | store-versions | ✅ | 5.6 s | 26.11.0-trunk.27 · 6.18.44-current-meson64 |
 
 ??? failure "Mekotronics R58S2 01 — fail"
 
@@ -359,20 +367,20 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "NanoPi M4V2 01 — pass"
 
-    `nanopim4v2` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `nanopim4v2` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 16.4 s | — |
-    | reboot | ✅ | 53.0 s | power-cycle · up 26 s |
-    | hw-performance | ✅ | 21.2 s | AES 1022 · mem 6300 · disk W 54 / R 60 MB/s · 47.5 °C · 1416 MHz |
-    | dvfs | ✅ | 19.6 s | ondemand · 408–1416 MHz (peak 1800) |
-    | network-iperf | ✅ | 452.3 s | end0 ↑938/↓939 (1GE) · wlan0 ↑157/↓193 (Wi-Fi 5) · wlx803f5d16af63 ↑120/↓199 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 19.5 s | stable |
-    | reboot | ✅ | 53.5 s | power-cycle · up 27 s |
-    | store-versions | ✅ | 4.8 s | 26.8.3 · 6.18.44-current-rockchip64 |
+    | upgrade | ✅ | 105.9 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 53.1 s | power-cycle · up 25 s |
+    | hw-performance | ✅ | 20.9 s | AES 1019 · mem 6600 · disk W 54 / R 60 MB/s · 46.2 °C · 1416 MHz |
+    | dvfs | ✅ | 19.8 s | ondemand · 408–1416 MHz (peak 1800) |
+    | network-iperf | ✅ | 163.6 s | end0 ↑939/↓939 (1GE) · wlan0 ↑131/↓138 (Wi-Fi 5) · wlx803f5d16af63 ↑128/↓153 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 79.1 s | stable |
+    | reboot | ✅ | 55.5 s | power-cycle · up 27 s |
+    | store-versions | ✅ | 4.7 s | 26.11.0-trunk.27 · 6.18.44-current-rockchip64 |
 
-    **Power** — idle 2.50 W · avg 6.65 W · peak 12.60 W · 524 samples
+    **Power** — idle 3.00 W · avg 7.06 W · peak 12.50 W · 411 samples
 
 ??? failure "NanoPi M5 01 — fail"
 
@@ -427,9 +435,9 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 39.9 s | AES 25 · mem 2200 · disk W 19 / R 22 MB/s · 46.7 °C · 1296 MHz |
-    | dvfs | ✅ | 33.2 s | ondemand · 480–1296 MHz (peak 1296) |
-    | network-iperf | ✅ | 249.1 s | end0 ↑707/↓916 (1GE) · wlan0 ↑2/↓4 (Wi-Fi 4) Mbps |
+    | hw-performance | ✅ | 39.8 s | AES 25 · mem 2200 · disk W 19 / R 22 MB/s · 44.9 °C · 1296 MHz |
+    | dvfs | ✅ | 32.9 s | ondemand · 480–1296 MHz (peak 1296) |
+    | network-iperf | ✅ | 70.8 s | end0 ↑707/↓941 (1GE) · wlan0 ↑20/↓23 (Wi-Fi 4) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
     | store-versions | ✅ | 7.2 s | 26.8.3 · 6.18.38-current-sunxi |
@@ -560,18 +568,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "NanoPi R76S 01 — pass"
 
-    `nanopi-r76s` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `nanopi-r76s` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 11.3 s | — |
-    | reboot | ✅ | 35.2 s | warm · up 17 s |
-    | hw-performance | ✅ | 17.8 s | AES 1299 · mem 8800 · disk W 62 / R 70 MB/s · 49.9 °C · 2016 MHz |
-    | dvfs | ✅ | 17.0 s | ondemand · 408–2016 MHz (peak 2208) |
-    | network-iperf | ✅ | 362.2 s | end0 ↑2353/↓2354 (2.5GE) · end1 ↑2351/↓2237 (2.5GE) · wlan0 ↑85/↓135 (Wi-Fi 5) · wlxe0e1a933de37 ↑125/↓213 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 14.0 s | stable |
+    | upgrade | ✅ | 91.1 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 40.2 s | warm · up 23 s |
+    | hw-performance | ✅ | 17.6 s | AES 1310 · mem 8800 · disk W 62 / R 70 MB/s · 46.2 °C · 2016 MHz |
+    | dvfs | ✅ | 17.1 s | ondemand · 408–2016 MHz (peak 2208) |
+    | network-iperf | ✅ | 120.8 s | end0 ↑2353/↓2354 (2.5GE) · end1 ↑2353/↓2254 (2.5GE) · wlan0 ↑98/↓180 (Wi-Fi 5) · wlxe0e1a933de37 ↑69/↓142 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 64.3 s | stable |
     | reboot | ✅ | 36.6 s | warm · up 18 s |
-    | store-versions | ✅ | 4.0 s | 26.8.3 · 7.1.8-edge-rockchip64 |
+    | store-versions | ✅ | 3.8 s | 26.11.0-trunk.27 · 7.1.8-edge-rockchip64 |
 
 ??? success "NanoPi R76S 02 — pass"
 
@@ -620,35 +628,35 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Odroid C4 01 — pass"
 
-    `odroidc4` · **inplace** · image `26.11.0-trunk.6` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `odroidc4` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 17.4 s | — |
-    | reboot | ✅ | 41.2 s | power-cycle · up 16 s |
-    | hw-performance | ✅ | 21.7 s | AES 979 · mem 5300 · disk W 30 / R 77 MB/s · 44.7 °C · 2100 MHz |
-    | dvfs | ✅ | 18.9 s | ondemand · 1000–2100 MHz (peak 2100) |
-    | network-iperf | ✅ | 235.4 s | end0 ↑940/↓942 (1GE) · wlx24050fdd332b ↑113/↓98 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 19.6 s | stable |
-    | reboot | ✅ | 40.8 s | power-cycle · up 16 s |
-    | store-versions | ✅ | 4.3 s | 26.11.0-trunk.6 · 6.18.44-current-meson64 |
+    | upgrade | ✅ | 131.8 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 41.0 s | power-cycle · up 16 s |
+    | hw-performance | ✅ | 21.7 s | AES 980 · mem 5200 · disk W 30 / R 78 MB/s · 44.1 °C · 2100 MHz |
+    | dvfs | ✅ | 19.3 s | ondemand · 1000–2100 MHz (peak 2100) |
+    | network-iperf | ✅ | 132.6 s | end0 ↑941/↓941 (1GE) · wlx24050fdd332b ↑77/↓128 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 96.6 s | stable |
+    | reboot | ✅ | 41.9 s | power-cycle · up 16 s |
+    | store-versions | ✅ | 4.4 s | 26.11.0-trunk.27 · 6.18.44-current-meson64 |
 
 ??? success "Odroid M1 01 — pass"
 
-    `odroidm1` · **inplace** · image `26.11.0-trunk.6` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `odroidm1` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 17.7 s | — |
-    | reboot | ✅ | 52.7 s | power-cycle · up 21 s |
-    | hw-performance | ✅ | 16.8 s | AES 914 · mem 5000 · disk W 1037 / R 1040 MB/s · 39.4 °C · 1992 MHz |
-    | dvfs | ✅ | 21.6 s | ondemand · 408–1992 MHz (peak 1992) |
-    | network-iperf | ✅ | 285.4 s | eth0 ↑604/↓941 (1GE) · wlx40a5eff39254 ↑192/↓183 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 21.3 s | stable |
-    | reboot | ✅ | 54.9 s | power-cycle · up 23 s |
-    | store-versions | ✅ | 4.6 s | 26.11.0-trunk.6 · 6.18.44-current-rockchip64 |
+    | upgrade | ✅ | 108.6 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 52.5 s | power-cycle · up 21 s |
+    | hw-performance | ✅ | 16.8 s | AES 914 · mem 5000 · disk W 1038 / R 1020 MB/s · 37.2 °C · 1992 MHz |
+    | dvfs | ✅ | 21.5 s | ondemand · 408–1992 MHz (peak 1992) |
+    | network-iperf | ✅ | 86.8 s | eth0 ↑551/↓941 (1GE) · wlx40a5eff39254 ↑153/↓136 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 73.9 s | stable |
+    | reboot | ✅ | 53.3 s | power-cycle · up 20 s |
+    | store-versions | ✅ | 4.7 s | 26.11.0-trunk.27 · 6.18.44-current-rockchip64 |
 
-    **Power** — idle 1.60 W · avg 4.86 W · peak 8.30 W · 383 samples
+    **Power** — idle 1.60 W · avg 5.22 W · peak 10.90 W · 341 samples
 
 ??? success "Odroid N2 01 — pass"
 
@@ -697,35 +705,28 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     | reboot | ✅ | 38.3 s | warm · up 24 s |
     | store-versions | ✅ | 3.8 s | 26.11.0-trunk.6 · 6.18.43-current-meson64 |
 
-??? failure "Odroid XU4 01 — fail"
+??? success "Odroid XU4 01 — pass"
 
-    `odroidxu4` · **inplace** · image `26.11.0-trunk.6` · 1 ✅ · 1 ❌ · 6 ⏭️
+    `odroidxu4` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 82.9 s | nightly · 26.11.0-trunk.6 → 26.11.0-trunk.6 |
-    | reboot | ❌ | 210.0 s | power-cycle |
-    | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | dvfs | ⏭️ | 0.0 s | — |
-    | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | restore-stable | ⏭️ | 0.0 s | — |
-    | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ⏭️ | 0.0 s | — |
+    | upgrade | ✅ | 173.0 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 61.2 s | power-cycle · up 31 s |
+    | hw-performance | ✅ | 37.9 s | AES 71 · mem 5500 · disk W 1 / R 54 MB/s · 57 °C · 1400 MHz |
+    | dvfs | ✅ | 29.1 s | ondemand · 600–1400 MHz (peak 2000) |
+    | network-iperf | ✅ | 278.2 s | enx001e0636e380 ↑924/↓941 (1GE) Mbps |
+    | restore-stable | ✅ | 118.2 s | stable |
+    | reboot | ✅ | 57.2 s | power-cycle · up 31 s |
+    | store-versions | ✅ | 7.0 s | 26.11.0-trunk.27 · 6.6.151-current-odroidxu4 |
 
 ??? failure "Orange Pi 3 01 — fail"
 
-    `orangepi3` · **inplace** · image `26.11.0-trunk.6` · 1 ✅ · 1 ❌ · 6 ⏭️
+    `orangepi3` · **inplace** · image `26.11.0-trunk.19` · 0 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 130.6 s | nightly · 26.11.0-trunk.6 → 26.11.0-trunk.6 |
-    | reboot | ❌ | 213.7 s | power-cycle |
-    | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | dvfs | ⏭️ | 0.0 s | — |
-    | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | restore-stable | ⏭️ | 0.0 s | — |
-    | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ⏭️ | 0.0 s | — |
+    | reachable | ❌ | 0.0 s | ip=10.0.50.41 · reachable=False · port=22 |
 
 ??? failure "Orange Pi 5 01 — fail"
 
@@ -744,20 +745,20 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Orange Pi 5 Plus 01 — pass"
 
-    `orangepi5-plus` · **inplace** · image `26.11.0-trunk.5` · 8 ✅ · 0 ❌ · 0 ⏭️
+    `orangepi5-plus` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 159.7 s | nightly · 26.11.0-trunk.5 → 26.11.0-trunk.6 |
-    | reboot | ✅ | 57.8 s | power-cycle · up 27 s |
-    | hw-performance | ✅ | 19.0 s | AES 1256 · mem 10000 · disk W 50 / R 56 MB/s · 53.6 °C · 1800 MHz |
-    | dvfs | ✅ | 45.0 s | ondemand · 408–1800 MHz (peak 2400) |
-    | network-iperf | ✅ | 78.6 s | enP3p49s0 ↑2353/↓2243 (2.5GE) · enP4p65s0 ↑940/↓941 (1GE) · wlxe0e1a9380c53 ↑189/↓142 (Wi-Fi 6) Mbps |
-    | restore-stable | ✅ | 76.4 s | stable |
-    | reboot | ✅ | 54.0 s | power-cycle · up 21 s |
-    | store-versions | ✅ | 4.9 s | 26.11.0-trunk.6 · 6.18.43-current-rockchip64 |
+    | upgrade | ✅ | 107.2 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 52.2 s | power-cycle · up 27 s |
+    | hw-performance | ✅ | 17.5 s | AES 1263 · mem 14000 · disk W 55 / R 63 MB/s · 45.3 °C · 1800 MHz |
+    | dvfs | ✅ | 16.2 s | ondemand · 1800–1800 MHz (peak 2256) |
+    | network-iperf | ✅ | 232.1 s | enP3p49s0 ↑2351/↓2223 (2.5GE) · enP4p65s0 ↑941/↓941 (1GE) · wlxe0e1a9380c53 ↑636/↓427 (Wi-Fi 6) Mbps |
+    | restore-stable | ✅ | 89.1 s | stable |
+    | reboot | ✅ | 51.0 s | power-cycle · up 26 s |
+    | store-versions | ✅ | 3.4 s | 26.11.0-trunk.27 · 6.1.115-vendor-rk35xx |
 
-    **Power** — idle 1.90 W · avg 7.13 W · peak 17.00 W · 399 samples
+    **Power** — idle 2.70 W · avg 6.07 W · peak 13.50 W · 458 samples
 
 ??? failure "Orange Pi 5 Plus 02 — fail"
 
@@ -776,18 +777,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Orange Pi One+ 01 — pass"
 
-    `orangepioneplus` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `orangepioneplus` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 23.5 s | — |
-    | reboot | ✅ | 35.7 s | warm · up 17 s |
-    | hw-performance | ✅ | 29.6 s | AES 839 · mem 4600 · disk W 21 / R 23 MB/s · 61.5 °C · 1800 MHz |
+    | upgrade | ✅ | 146.6 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 33.5 s | warm · up 17 s |
+    | hw-performance | ✅ | 30.0 s | AES 835 · mem 4600 · disk W 21 / R 23 MB/s · 61.6 °C · 1800 MHz |
     | dvfs | ✅ | 22.6 s | ondemand · 480–1800 MHz (peak 1800) |
-    | network-iperf | ✅ | 201.6 s | end0 ↑912/↓941 (1GE) · wlx00e04c881724 ↑92/↓67 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 28.6 s | stable |
-    | reboot | ✅ | 33.8 s | warm · up 17 s |
-    | store-versions | ✅ | 5.8 s | 26.8.3 · 7.1.8-edge-sunxi64 |
+    | network-iperf | ✅ | 227.7 s | end0 ↑916/↓942 (1GE) · wlx00e04c881724 ↑121/↓101 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 97.8 s | stable |
+    | reboot | ✅ | 35.5 s | warm · up 19 s |
+    | store-versions | ✅ | 5.1 s | 26.11.0-trunk.27 · 7.1.8-edge-sunxi64 |
 
 ??? failure "Orange Pi PC + 01 — fail"
 
@@ -806,18 +807,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Orange Pi PC2 01 — pass"
 
-    `orangepipc2` · **inplace** · image `26.8.1` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `orangepipc2` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 29.0 s | — |
-    | reboot | ✅ | 59.4 s | power-cycle · up 34 s |
-    | hw-performance | ✅ | 38.8 s | AES 637 · mem 3500 · disk W 9 / R 23 MB/s · 58.4 °C · 1368 MHz |
-    | dvfs | ✅ | 22.8 s | ondemand · 480–1368 MHz (peak 1368) |
-    | network-iperf | ✅ | 49.2 s | end0 ↑894/↓882 (1GE) Mbps |
-    | restore-stable | ✅ | 29.5 s | stable |
-    | reboot | ✅ | 54.7 s | power-cycle · up 29 s |
-    | store-versions | ✅ | 5.7 s | 26.8.3 · 6.18.44-current-sunxi64 |
+    | upgrade | ✅ | 244.0 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 60.0 s | power-cycle · up 34 s |
+    | hw-performance | ✅ | 38.2 s | AES 638 · mem 3500 · disk W 9 / R 22 MB/s · 62.7 °C · 1368 MHz |
+    | dvfs | ✅ | 24.1 s | ondemand · 480–1368 MHz (peak 1368) |
+    | network-iperf | ✅ | 39.4 s | end0 ↑847/↓872 (1GE) Mbps |
+    | restore-stable | ✅ | 182.9 s | stable |
+    | reboot | ✅ | 59.0 s | power-cycle · up 34 s |
+    | store-versions | ✅ | 5.2 s | 26.11.0-trunk.27 · 6.18.44-current-sunxi64 |
 
 ??? success "Orange Pi Prime 01 — pass"
 
@@ -827,27 +828,27 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 45.1 s | AES 379 · mem 2100 · disk W 21 / R 23 MB/s · 42.7 °C · None MHz |
-    | dvfs | ➖ | 3.8 s | — |
-    | network-iperf | ✅ | 299.6 s | end0 ↑873/↓941 (1GE) · wlan0 ↑21/↓20 (Wi-Fi 4) Mbps |
+    | hw-performance | ✅ | 45.0 s | AES 379 · mem 2100 · disk W 21 / R 23 MB/s · 38.2 °C · None MHz |
+    | dvfs | ➖ | 3.1 s | — |
+    | network-iperf | ✅ | 166.3 s | end0 ↑883/↓787 (1GE) · wlan0 ↑25/↓34 (Wi-Fi 4) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 6.6 s | 26.8.3 · 6.18.38-current-sunxi64 |
+    | store-versions | ✅ | 6.5 s | 26.8.3 · 6.18.38-current-sunxi64 |
 
 ??? success "Orange Pi R1 01 — pass"
 
-    `orangepi-r1` · **inplace** · image `26.11.0-trunk.6` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `orangepi-r1` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 40.3 s | — |
-    | reboot | ✅ | 52.2 s | warm · up 34 s |
-    | hw-performance | ✅ | 39.8 s | AES 25 · mem 1400 · disk W 21 / R 23 MB/s · 62.4 °C · 1296 MHz |
-    | dvfs | ✅ | 35.0 s | ondemand · 480–1296 MHz (peak 1296) |
-    | network-iperf | ✅ | 383.2 s | enxc0742bfffce9 ↑94/↓94 (10/100ME) · wlan0 ↑12/↓31 (Wi-Fi 4) · wlan1 ↑28/↓9 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 46.4 s | stable |
-    | reboot | ✅ | 50.4 s | warm · up 32 s |
-    | store-versions | ✅ | 8.3 s | 26.11.0-trunk.6 · 6.18.44-current-sunxi |
+    | upgrade | ✅ | 245.8 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 52.9 s | warm · up 35 s |
+    | hw-performance | ✅ | 39.7 s | AES 25 · mem 1400 · disk W 21 / R 23 MB/s · 63.2 °C · 1296 MHz |
+    | dvfs | ✅ | 34.0 s | ondemand · 480–1296 MHz (peak 1296) |
+    | network-iperf | ✅ | 124.6 s | enxc0742bfffce9 ↑94/↓94 (10/100ME) · wlan0 ↑21/↓28 (Wi-Fi 4) · wlan1 ↑12/↓31 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 158.3 s | stable |
+    | reboot | ✅ | 53.6 s | warm · up 34 s |
+    | store-versions | ✅ | 9.1 s | 26.11.0-trunk.27 · 6.18.44-current-sunxi |
 
 ??? failure "Orange Pi Win 01 — fail"
 
@@ -896,18 +897,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Orange Pi Zero2 01 — pass"
 
-    `orangepizero2` · **inplace** · image `26.11.0-trunk.6` · 8 ✅ · 0 ❌ · 0 ⏭️
+    `orangepizero2` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 87.6 s | nightly · 26.11.0-trunk.6 → 26.11.0-trunk.6 |
-    | reboot | ✅ | 45.5 s | power-cycle · up 19 s |
-    | hw-performance | ✅ | 33.3 s | AES 705 · mem 3000 · disk W 21 / R 22 MB/s · 60.6 °C · 1512 MHz |
+    | upgrade | ✅ | 160.3 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 44.2 s | power-cycle · up 19 s |
+    | hw-performance | ✅ | 32.8 s | AES 705 · mem 3000 · disk W 21 / R 23 MB/s · 60.9 °C · 1512 MHz |
     | dvfs | ✅ | 26.3 s | ondemand · 480–1512 MHz (peak 1512) |
-    | network-iperf | ✅ | 272.1 s | end0 ↑875/↓941 (1GE) · wlx7c023a625db1 ↑38/↓31 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 63.6 s | stable |
-    | reboot | ✅ | 45.4 s | power-cycle · up 20 s |
-    | store-versions | ✅ | 5.9 s | 26.11.0-trunk.6 · 7.1.8-edge-sunxi64 |
+    | network-iperf | ✅ | 123.7 s | end0 ↑877/↓941 (1GE) · wlx7c023a625db1 ↑35/↓34 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 136.2 s | stable |
+    | reboot | ✅ | 44.2 s | power-cycle · up 19 s |
+    | store-versions | ✅ | 6.0 s | 26.11.0-trunk.27 · 7.1.8-edge-sunxi64 |
 
 ??? success "OrangePi 3 LTS 01 — pass"
 
@@ -917,12 +918,12 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 20.6 s | AES 750 · mem 4100 · disk W 55 / R 127 MB/s · 63.9 °C · 1608 MHz |
-    | dvfs | ✅ | 21.8 s | ondemand · 480–1608 MHz (peak 1608) |
-    | network-iperf | ✅ | 163.3 s | end0 ↑918/↓941 (1GE) · wlan0 ↑30/↓24 (Wi-Fi 5) Mbps |
+    | hw-performance | ✅ | 20.8 s | AES 750 · mem 4100 · disk W 55 / R 127 MB/s · 63.9 °C · 1608 MHz |
+    | dvfs | ✅ | 21.4 s | ondemand · 480–1608 MHz (peak 1608) |
+    | network-iperf | ✅ | 155.0 s | end0 ↑921/↓941 (1GE) · wlan0 ↑42/↓9 (Wi-Fi 5) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 4.9 s | 26.8.3 · 7.0.14-edge-sunxi64 |
+    | store-versions | ✅ | 4.8 s | 26.8.3 · 7.0.14-edge-sunxi64 |
 
 ??? failure "Pine H64 01 — fail"
 
@@ -941,67 +942,67 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Radxa Dragon Q6A 01 — pass"
 
-    `radxa-dragon-q6a` · **inplace** · image `26.5.1` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `radxa-dragon-q6a` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 10.0 s | — |
-    | reboot | ✅ | 135.2 s | power-cycle · up 106 s |
-    | hw-performance | ✅ | 13.3 s | AES 1510 · mem 15500 · disk W 240 / R 1146 MB/s · 47.3 °C · 1958 MHz |
+    | upgrade | ✅ | 77.4 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 136.2 s | power-cycle · up 106 s |
+    | hw-performance | ✅ | 13.2 s | AES 1511 · mem 18600 · disk W 252 / R 1164 MB/s · 48.4 °C · 1958 MHz |
     | dvfs | ✅ | 14.0 s | ondemand · 300–1958 MHz (peak 2707) |
-    | network-iperf | ✅ | 76.5 s | enp1s0 ↑941/↓940 (1GE) Mbps |
-    | restore-stable | ✅ | 10.7 s | stable |
-    | reboot | ✅ | 136.4 s | power-cycle · up 106 s |
-    | store-versions | ✅ | 3.6 s | 26.5.1 · 6.18.2-current-qcs6490 |
+    | network-iperf | ✅ | 28.2 s | enp1s0 ↑941/↓940 (1GE) Mbps |
+    | restore-stable | ✅ | 64.8 s | stable |
+    | reboot | ✅ | 135.8 s | power-cycle · up 106 s |
+    | store-versions | ✅ | 3.6 s | 26.11.0-trunk.27 · 6.18.2-current-qcs6490 |
 
-    **Power** — idle 1.00 W · avg 2.08 W · peak 6.80 W · 325 samples
+    **Power** — idle 1.00 W · avg 2.59 W · peak 8.30 W · 385 samples
 
 ??? success "Radxa ZERO 3 01 — pass"
 
-    `radxa-zero3` · **inplace** · image `26.5.1` · 3 ✅ · 1 ❌ · 4 ⏭️
+    `radxa-zero3` · **inplace** · image `26.5.1` · 4 ✅ · 0 ❌ · 4 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 36.6 s | AES 719 · mem 3900 · disk W 21 / R 22 MB/s · 51.9 °C · 1416 MHz |
-    | dvfs | ✅ | 31.1 s | ondemand · 408–1416 MHz (peak 1416) |
-    | network-iperf | ❌ | 87.3 s | wlan0 ↑0/↓3 (Wi-Fi 6) Mbps |
+    | hw-performance | ✅ | 32.7 s | AES 720 · mem 3900 · disk W 21 / R 22 MB/s · 50.6 °C · 1416 MHz |
+    | dvfs | ✅ | 25.4 s | ondemand · 408–1416 MHz (peak 1416) |
+    | network-iperf | ✅ | 50.5 s | wlan0 ↑11/↓10 (Wi-Fi 6) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 9.1 s | 26.5.1 · 6.18.24-current-rockchip64 |
+    | store-versions | ✅ | 9.5 s | 26.5.1 · 6.18.24-current-rockchip64 |
 
 ??? success "Raspberry Pi 01 — pass"
 
-    `rpi4b` · **inplace** · image `26.8.1` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `rpi4b` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 6.6 s | — |
-    | reboot | ✅ | 39.8 s | power-cycle · up 17 s |
-    | hw-performance | ✅ | 14.2 s | AES 1368 · mem 12100 · disk W 53 / R 89 MB/s · 70.5 °C · 2400 MHz |
-    | dvfs | ✅ | 13.1 s | ondemand · 1500–2400 MHz (peak 2400) |
-    | network-iperf | ✅ | 233.0 s | end0 ↑936/↓941 (1GE) · wlan0 ↑48/↓29 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 8.1 s | stable |
-    | reboot | ✅ | 39.9 s | power-cycle · up 17 s |
-    | store-versions | ✅ | 3.8 s | 26.8.1 · 6.18.44-current-bcm2711 |
+    | upgrade | ✅ | 50.2 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 42.7 s | power-cycle · up 19 s |
+    | hw-performance | ✅ | 14.3 s | AES 1368 · mem 12100 · disk W 56 / R 90 MB/s · 70.5 °C · 2400 MHz |
+    | dvfs | ✅ | 13.3 s | ondemand · 1500–2400 MHz (peak 2400) |
+    | network-iperf | ✅ | 50.9 s | end0 ↑936/↓941 (1GE) · wlan0 ↑28/↓38 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 37.6 s | stable |
+    | reboot | ✅ | 44.2 s | power-cycle · up 21 s |
+    | store-versions | ✅ | 3.0 s | 26.11.0-trunk.27 · 6.18.44-current-bcm2711 |
 
-    **Power** — idle 2.10 W · avg 4.93 W · peak 8.90 W · 289 samples
+    **Power** — idle 2.20 W · avg 5.30 W · peak 8.30 W · 205 samples
 
-??? failure "Raspberry Pi 02 — fail"
+??? success "Raspberry Pi 02 — pass"
 
-    `rpi4b` · **inplace** · image `26.8.0-trunk.314` · 1 ✅ · 1 ❌ · 6 ⏭️
+    `rpi4b` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 158.6 s | nightly · 26.8.0-trunk.314 → 26.8.0-trunk.314 |
-    | reboot | ❌ | 199.5 s | warm |
-    | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | dvfs | ⏭️ | 0.0 s | — |
-    | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | restore-stable | ⏭️ | 0.0 s | — |
-    | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ⏭️ | 0.0 s | — |
+    | upgrade | ✅ | 170.5 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 37.5 s | warm · up 19 s |
+    | hw-performance | ✅ | 33.6 s | AES 40 · mem 2500 · disk W 20 / R 22 MB/s · 61.8 °C · 1200 MHz |
+    | dvfs | ✅ | 26.5 s | ondemand · 600–1200 MHz (peak 1200) |
+    | network-iperf | ✅ | 88.5 s | enxb827eb253a53 ↑94/↓94 (10/100ME) · wlan0 ↑22/↓36 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 122.5 s | stable |
+    | reboot | ✅ | 38.1 s | warm · up 19 s |
+    | store-versions | ✅ | 6.0 s | 26.11.0-trunk.27 · 6.18.44-current-bcm2711 |
 
 ??? success "ROCK 2F 01 — pass"
 
@@ -1011,12 +1012,12 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 29.8 s | AES 818 · mem 5900 · disk W 23 / R 65 MB/s · 50.9 °C · 2016 MHz |
-    | dvfs | ✅ | 24.9 s | ondemand · 408–2016 MHz (peak 2016) |
-    | network-iperf | ✅ | 125.0 s | wlan0 ↑33/↓57 (Wi-Fi 6) Mbps |
+    | hw-performance | ✅ | 27.5 s | AES 822 · mem 5900 · disk W 32 / R 65 MB/s · 49 °C · 2016 MHz |
+    | dvfs | ✅ | 25.1 s | ondemand · 408–2016 MHz (peak 2016) |
+    | network-iperf | ✅ | 100.7 s | wlan0 ↑78/↓56 (Wi-Fi 6) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 5.3 s | 26.5.1 · 6.1.115-vendor-rk35xx |
+    | store-versions | ✅ | 5.4 s | 26.5.1 · 6.1.115-vendor-rk35xx |
 
 ??? failure "Rock 5B 01 — fail"
 
@@ -1035,18 +1036,11 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? failure "Rock 5B 02 — fail"
 
-    `rock-5b` · **inplace** · image `26.11.0-trunk.6` · 1 ✅ · 1 ❌ · 6 ⏭️
+    `rock-5b` · **inplace** · image `26.8.3` · 0 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ✅ | 33.5 s | nightly · 26.11.0-trunk.6 → 26.11.0-trunk.6 |
-    | reboot | ❌ | 214.8 s | power-cycle |
-    | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | dvfs | ⏭️ | 0.0 s | — |
-    | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | restore-stable | ⏭️ | 0.0 s | — |
-    | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ⏭️ | 0.0 s | — |
+    | reachable | ❌ | 0.0 s | ip=10.0.50.32 · reachable=False · port=22 |
 
 ??? failure "Rock 5B 03 — fail"
 
@@ -1125,33 +1119,26 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? failure "Rock 5B Plus 01 — fail"
 
-    `rock-5b-plus` · **inplace** · image `26.8.0-trunk.236` · 0 ✅ · 1 ❌ · 7 ⏭️
+    `rock-5b-plus` · **inplace** · image `26.8.3` · 0 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 8.2 s | — |
-    | reboot | ❌ | 208.5 s | power-cycle |
-    | hw-perf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | dvfs | ⏭️ | 0.0 s | — |
-    | net-iperf | ⏭️ | 0.0 s | board down after reboot/power-cycle |
-    | restore-stable | ⏭️ | 0.0 s | — |
-    | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ⏭️ | 0.0 s | — |
+    | reachable | ❌ | 0.0 s | ip=10.0.50.47 · reachable=False · port=22 |
 
 ??? success "Rock 5T 01 — pass"
 
-    `rock-5t` · **inplace** · image `26.8.3` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `rock-5t` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 11.5 s | — |
-    | reboot | ✅ | 45.0 s | power-cycle · up 16 s |
-    | hw-performance | ✅ | 17.9 s | AES 1249 · mem 7600 · disk W 52 / R 82 MB/s · 60.1 °C · 1800 MHz |
-    | dvfs | ✅ | 15.6 s | ondemand · 408–1800 MHz (peak 2400) |
-    | network-iperf | ✅ | 198.8 s | enP3p49s0 ↑2350/↓2354 (2.5GE) · enP4p65s0 ↑2353/↓2354 (2.5GE) · wlP2p33s0 ↑341/↓350 (Wi-Fi 6) · wlx7cdd90ebf00a ↑93/↓124 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 14.0 s | stable |
-    | reboot | ✅ | 44.9 s | power-cycle · up 15 s |
-    | store-versions | ✅ | 4.0 s | 26.8.3 · 6.18.44-current-rockchip64 |
+    | upgrade | ✅ | 84.4 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 44.2 s | power-cycle · up 16 s |
+    | hw-performance | ✅ | 18.1 s | AES 1250 · mem 10000 · disk W 51 / R 83 MB/s · 59.2 °C · 1800 MHz |
+    | dvfs | ✅ | 16.4 s | ondemand · 408–1800 MHz (peak 2400) |
+    | network-iperf | ✅ | 117.5 s | enP3p49s0 ↑2353/↓2354 (2.5GE) · enP4p65s0 ↑2353/↓2354 (2.5GE) · wlP2p33s0 ↑323/↓258 (Wi-Fi 6) · wlx7cdd90ebf00a ↑94/↓119 (Wi-Fi 4) Mbps |
+    | restore-stable | ✅ | 66.5 s | stable |
+    | reboot | ✅ | 45.2 s | power-cycle · up 17 s |
+    | store-versions | ✅ | 3.9 s | 26.11.0-trunk.27 · 6.18.44-current-rockchip64 |
 
 ??? success "Rock 5T 02 — pass"
 
@@ -1185,18 +1172,18 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 ??? success "Rockpi E 01 — pass"
 
-    `rockpi-e` · **inplace** · image `26.8.1` · 7 ✅ · 0 ❌ · 1 ⏭️
+    `rockpi-e` · **inplace** · image `26.11.0-trunk.27` · 8 ✅ · 0 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 23.0 s | — |
-    | reboot | ✅ | 53.8 s | power-cycle · up 24 s |
-    | hw-performance | ✅ | 31.3 s | AES 603 · mem 3300 · disk W 21 / R 23 MB/s · 64.6 °C · 1296 MHz |
-    | dvfs | ✅ | 24.1 s | ondemand · 408–1296 MHz (peak 1296) |
-    | network-iperf | ✅ | 212.1 s | end0 ↑940/↓941 (1GE) · wlx7ca7b020e87c ↑177/↓204 (Wi-Fi 5) Mbps |
-    | restore-stable | ✅ | 30.9 s | stable |
-    | reboot | ✅ | 52.9 s | power-cycle · up 24 s |
-    | store-versions | ✅ | 5.5 s | 26.8.1 · 6.18.44-current-rockchip64 |
+    | upgrade | ✅ | 200.2 s | nightly · 26.11.0-trunk.27 → 26.11.0-trunk.27 |
+    | reboot | ✅ | 53.3 s | power-cycle · up 24 s |
+    | hw-performance | ✅ | 31.7 s | AES 598 · mem 3300 · disk W 21 / R 23 MB/s · 62.9 °C · 1296 MHz |
+    | dvfs | ✅ | 25.2 s | ondemand · 408–1296 MHz (peak 1296) |
+    | network-iperf | ✅ | 61.7 s | end0 ↑941/↓941 (1GE) · wlx7ca7b020e87c ↑160/↓205 (Wi-Fi 5) Mbps |
+    | restore-stable | ✅ | 147.9 s | stable |
+    | reboot | ✅ | 49.6 s | power-cycle · up 25 s |
+    | store-versions | ✅ | 13.0 s | 26.11.0-trunk.27 · 6.18.44-current-rockchip64 |
 
 ??? success "SpacemiT K3 Pico-ITX 01 — pass"
 
@@ -1206,29 +1193,22 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 22.3 s | AES 796 · mem 12000 · disk W 24 / R 40 MB/s · 63 °C · 2200 MHz |
-    | dvfs | ✅ | 15.4 s | performance · 614–2200 MHz (peak 2200) |
-    | network-iperf | ✅ | 166.7 s | eth0 ↑941/↓941 (1GE) · wlan0 ↑68/↓174 (Wi-Fi 6) Mbps |
+    | hw-performance | ✅ | 22.2 s | AES 797 · mem 12000 · disk W 25 / R 40 MB/s · 62 °C · 2200 MHz |
+    | dvfs | ✅ | 15.5 s | performance · 614–2200 MHz (peak 2200) |
+    | network-iperf | ✅ | 60.2 s | eth0 ↑941/↓941 (1GE) · wlan0 ↑56/↓170 (Wi-Fi 6) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
     | store-versions | ✅ | 3.7 s | 26.8.3 · 6.18.3-legacy-spacemit-k3 |
 
-    **Power** — idle 13.60 W · avg 14.45 W · peak 22.70 W · 175 samples
+    **Power** — idle 13.50 W · avg 14.87 W · peak 22.70 W · 88 samples
 
-??? success "Tanix TX6 01 — pass"
+??? failure "Tanix TX6 01 — fail"
 
-    `tanix-tx6` · **inplace** · image `26.11.0-trunk.6` · 6 ✅ · 1 ❌ · 1 ⏭️
+    `tanix-tx6` · **inplace** · image `26.11.0-trunk.6` · 0 ✅ · 1 ❌ · 0 ⏭️
 
     | Module | Status | Time | Detail |
     |:--|:--:|--:|:--|
-    | upgrade | ⏭️ | 23.1 s | — |
-    | reboot | ✅ | 32.1 s | warm · up 13 s |
-    | hw-performance | ✅ | 20.2 s | AES 793 · mem 4400 · disk W 54 / R 128 MB/s · 71.6 °C · 1704 MHz |
-    | dvfs | ✅ | 21.6 s | ondemand · 480–1704 MHz (peak 1704) |
-    | network-iperf | ❌ | 224.3 s | end0 ↑94/↓94 (10/100ME) · wlan0 ↑0/↓0 (Wi-Fi 5) · wlx44334c47dec3 ↑42/↓29 (Wi-Fi 4) Mbps |
-    | restore-stable | ✅ | 23.5 s | stable |
-    | reboot | ✅ | 30.9 s | warm · up 12 s |
-    | store-versions | ✅ | 4.8 s | 26.11.0-trunk.6 · 6.18.44-current-sunxi64 |
+    | reachable | ❌ | 0.0 s | ip=10.0.50.21 · reachable=False · port=22 |
 
 ??? failure "Tinker Board 01 — fail"
 
@@ -1285,12 +1265,12 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     |:--|:--:|--:|:--|
     | upgrade | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | hw-performance | ✅ | 15.9 s | AES 1458 · mem 13000 · disk W 1547 / R 2303 MB/s · 47 °C · 2600 MHz |
-    | dvfs | ✅ | 15.4 s | ondemand · 800–2600 MHz (peak 2600) |
-    | network-iperf | ✅ | 193.4 s | enp1s0 ↑8260/↓9385 (10GE) · enp49s0 ↑8734/↓9385 (10GE) · wlp97s0 ↑96/↓72 (Wi-Fi 6) Mbps |
+    | hw-performance | ✅ | 15.7 s | AES 1402 · mem 13000 · disk W 1578 / R 2263 MB/s · 45 °C · 2600 MHz |
+    | dvfs | ✅ | 18.6 s | ondemand · 800–2600 MHz (peak 2600) |
+    | network-iperf | ✅ | 123.5 s | enp1s0 ↑8788/↓9372 (10GE) · enp49s0 ↑7633/↓9377 (10GE) · wlp97s0 ↑111/↓86 (Wi-Fi 6) Mbps |
     | restore-stable | ⏭️ | 0.0 s | — |
     | reboot | ⏭️ | 0.0 s | reboot |
-    | store-versions | ✅ | 4.3 s | 26.8.0-trunk.314 · 7.1.2-edge-arm64 |
+    | store-versions | ✅ | 4.4 s | 26.8.0-trunk.314 · 7.1.2-edge-arm64 |
 
 ??? failure "UEFI x86 01 — fail"
 


### PR DESCRIPTION
Tested-boards table refreshed from the autotests `test-results`
release (Publish fleet test results to docs).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1087"><kbd><br> Open WWW preview <br></kbd></a>