### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -15,7 +15,7 @@ update the table — the same mechanism behind the
 
 **70** boards — **56** operational, **14** broken.
 
-Reconcile made: 2026-08-30 15:59 UTC
+Reconcile made: 2026-08-30 16:10 UTC
 
 **Operational**
 


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1113"><kbd><br> Open WWW preview <br></kbd></a>