### PR TITLE
`Automatic` datacenter board list

### DIFF
--- a/docs/status/boards.md
+++ b/docs/status/boards.md
@@ -13,9 +13,9 @@ update the table — the same mechanism behind the
 
 <!-- BOARDS-START -->
 
-**77** boards — **60** operational, **17** broken.
+**73** boards — **60** operational, **13** broken.
 
-Reconcile made: 2026-08-31 16:02 UTC
+Reconcile made: 2026-08-31 16:09 UTC
 
 **Operational**
 
@@ -27,7 +27,7 @@ Reconcile made: 2026-08-31 16:02 UTC
 | Banana Pi M2Pro 01 | 10.0.50.80 | local | 1 GbE | Netgear S3300 (47) |
 | Banana Pi M5 01 | 10.0.50.63 | local | 1 GbE | Netgear GS348 (19) |
 | Banana Pi Pro 01 | 10.0.50.43 | local | 100 MbE | Netgear GS348 (8) |
-| Banana Pi R2 05 | 10.0.50.76 | local | 100 MbE | — |
+| Banana Pi R2 01 | 10.0.50.76 | local | 1 GbE | Netgear S3300 (24) |
 | BananaPi BPI-F3 01 | 10.0.50.53 | local | 1 GbE | Netgear S3300 (46) |
 | BigTreeTech CB1 01 | 10.0.50.62 | local | Wi-Fi 4 | Zyxel NWA130BE |
 | Clearfog Pro 01 | 10.0.50.24 | local | 1 GbE | TP-Link SG3428X (12) |
@@ -86,10 +86,6 @@ Reconcile made: 2026-08-31 16:02 UTC
 
 | Board | IP address | Boot | Link | Switch |
 |:--|:--|:--|--:|:--|
-| Banana Pi R2 01 | 10.0.50.48 | local | 1 GbE | Netgear S3300 (24) |
-| Banana Pi R2 02 | 10.0.50.14 | local | 100 MbE | — |
-| Banana Pi R2 03 | 10.0.50.57 | local | 100 MbE | — |
-| Banana Pi R2 04 | 10.0.50.75 | local | 1 GbE | — |
 | Inovato Quadra 01 | 10.0.50.39 | local | 100 MbE | Netgear GS348 (17) |
 | Khadas Edge2 01 | 10.0.20.134 | local | — | — |
 | Khadas VIM1 01 | 10.0.50.71 | local | 100 MbE | Netgear GS348 (3) |


### PR DESCRIPTION
Datacenter board list refreshed from NetBox by the reconcile action
(Inventory: scan & reconcile).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1137"><kbd><br> Open WWW preview <br></kbd></a>