### PR TITLE
docs: hide the stale version chip in the repository header

### DIFF
--- a/docs/css/armbian-extra.css
+++ b/docs/css/armbian-extra.css
@@ -60,3 +60,20 @@ pre.custom-bash-block, code.custom-bash-block {
   max-width: 260px;
   object-fit: contain;
 }
+
+/* Repository header: hide the version chip, keep stars and forks.
+ *
+ * mkdocs-material fills the repo card from the GitHub API and shows
+ * releases/latest as a "version". Ours is a leftover of the retired PDF
+ * pipeline, which tagged releases with a short commit SHA — the newest is
+ * e76674a from 2024-10-12 — so the chip advertises a stale hash as a version
+ * on a site that is redeployed on every push to main. Stars and forks stay:
+ * those are accurate.
+ *
+ * Done in CSS rather than by overriding the source.html partial because the
+ * facts are injected client-side (the JS builds `md-source__fact--<type>`);
+ * removing them in the template would take stars and forks with it.
+ */
+.md-source__fact--version {
+  display: none;
+}


### PR DESCRIPTION
> **TL;DR** — The repo card in the site header advertises version `e76674a`, a commit hash from October 2024, on a site that redeploys on every push to `main`. It is a leftover of the retired PDF release pipeline. Hide the version chip; keep stars and forks, which are correct.

## What the card shows vs. reality

mkdocs-material fills the header repo card from the GitHub API. Two of the three facts are accurate:

| Card | GitHub API | Verdict |
|---|---|---|
| ★ 234 | `stargazers_count: 234` | correct |
| ⑂ 209 | `forks_count: 209` | correct |
| 🏷 `e76674a` | `releases/latest → tag_name: e76674a`, published **2024-10-12** | real, but 22 months stale |

The card is reporting faithfully — the data behind it is the fossil.

## Where `e76674a` came from

It was never a version. The old PDF pipeline in `release.yaml` published a GitHub Release per push, tagged with the **short commit SHA**:

```yaml
      - name: Create Release
        uses: ncipollo/release-action@v1
        with:
          tag: ${{ steps.vars.outputs.sha_short }}
          name: ${{ steps.vars.outputs.timenow }}-${{ steps.vars.outputs.sha_short }}
          artifacts: armbian-document-${{ steps.vars.outputs.sha_short }}.pdf
```

That is why all **242 tags are 7-character hashes** and the newest release is literally named `2024-10-12-e76674a`. The job carrying it was commented out on 2024-11-20 in ab2258a4 ("Update workflows to remove PDF flow") and ca3df189 ("Disable the rest of the script as its not needed"), so releases stopped there. Today's `release.yaml` only builds the site and rsyncs it — it creates no tag or release at all.

## The change

```css
.md-source__fact--version {
  display: none;
}
```

The docs are continuously deployed and carry no version, so there is nothing meaningful to put in the chip's place.

**Why CSS and not a template override:** material injects these facts client-side, building the class as `md-source__fact--${t}` in JS. Overriding `partials/source.html` would mean dropping `data-md-component="source"`, which removes stars and forks too.

**Why no visual gap:** `.md-source__facts` is a flex row using `gap`, each item carrying its own `::before` icon — there are no textual separators — so hiding one item leaves no stray glyph or spacing.

## Verification

Local `mkdocs build` (mkdocs-material 9.7.6): the rule ships in `site/css/armbian-extra.css` and the stylesheet is linked from the built pages. `site/` is gitignored, so only the source CSS is committed.

## Alternatives not taken

- **Resume releasing** — re-enable a date-based release per deploy so the chip tracks the docs. Worth doing if the PDF artifact is wanted back.
- **Delete the stale releases/tags** — the API would then return none and material would omit the chip by itself, but that destroys 30 releases and 242 tags along with any link to the archived PDFs.


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1139"><kbd><br> Open WWW preview <br></kbd></a>