### PR TITLE
`Automatic` fleet test results

### DIFF
--- a/docs/status/board-tests.md
+++ b/docs/status/board-tests.md
@@ -13,7 +13,7 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
 
 <!-- FLEET-START -->
 
-**64** boards — **41** passed, **23** failed. Each card is the board's most recent test.
+**63** boards — **41** passed, **22** failed. Each card is the board's most recent test.
 
 ??? success "Arduino UNO Q 01 — pass"
 
@@ -918,14 +918,6 @@ Legend: ✅ pass · ❌ fail · ⏭️ skipped · ➖ not run.
     | store-versions | ✅ | 3.7 s | 26.8.3 · 6.18.3-legacy-spacemit-k3 |
 
     **Power** — idle 13.40 W · avg 14.40 W · peak 22.40 W · 148 samples
-
-??? failure "Tanix TX6 01 — fail"
-
-    `tanix-tx6` · **inplace** · image `26.11.0-trunk.6` · 0 ✅ · 1 ❌ · 0 ⏭️
-
-    | Module | Status | Time | Detail |
-    |:--|:--:|--:|:--|
-    | reachable | ❌ | 0.0 s | ip=10.0.50.21 · reachable=False · port=22 |
 
 ??? success "Tinker Board 01 — pass"
 


### PR DESCRIPTION
Tested-boards table refreshed from the autotests `test-results`
release (Publish fleet test results to docs).

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1164"><kbd><br> Open WWW preview <br></kbd></a>