### PR TITLE
Drop the leftover PDF plumbing

### DIFF
--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           body-template: |
-            [![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)
+            [![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)
 
             Documentation website preview will be available shortly:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,11 +137,6 @@ plugins:
         'Process_Managing_Workflow.md': 'contribute/index.md'
         'Process_Armbian-Task-Tracking.md': 'contribute/index.md'
         'Process_CI.md': 'contribute/automation.md'
-#   - with-pdf:
-#       author: Armbian documentation team
-#       copyright: © 2024 by Armbian
-#       cover_title: Armbian documentation
-#       cover_subtitle: Linux for ARM development boards
 
 markdown_extensions:
   - smarty

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ markdown>=3.6
 mkdocs>=1.6.0
 mkdocs-material>=9.5.31
 mkdocs-redirects>=1.2.2
-mkdocs-with-pdf>=0.9.3
 mdx_truly_sane_lists>=1.3.0
-weasyprint>=60.0

--- a/tools/mkArmbianDocs.py
+++ b/tools/mkArmbianDocs.py
@@ -120,11 +120,6 @@ extra:
 
 plugins:
    - search
-   - with-pdf:
-       author: Armbian documentation team
-       copyright: © 2024 by Armbian
-       cover_title: Armbian documentation
-       cover_subtitle: Linux for ARM development boards
 
 markdown_extensions:
   - smarty


### PR DESCRIPTION
> **TL;DR** — The PDF build is gone and its 242 releases/tags have been deleted. This removes the three bits of plumbing that outlived it.

## Releases and tags, already deleted

All **242** GitHub releases carrying an `armbian-document-<sha>.pdf` asset, and the **242** SHA-named tags they hung off. Every release in the repo had a PDF — nothing else was caught, and the tag set matched the release set exactly, 1:1, all seven-hex-character.

That was 617 MB of assets with 2302 downloads in total across two and a half years. 164 of those were on the last one, `e76674a`, largely because it was what `releases/latest` resolved to.

## What made them

The `deploy` job in `release.yaml`, which published a release per push tagged with the short commit SHA:

```yaml
- name: Create Release
  uses: ncipollo/release-action@v1
  with:
    tag: ${{ steps.vars.outputs.sha_short }}
    name: ${{ steps.vars.outputs.timenow }}-${{ steps.vars.outputs.sha_short }}
    artifacts: armbian-document-${{ steps.vars.outputs.sha_short }}.pdf
```

Commented out in ca3df189 (2024-11-20) and since removed, so nothing has generated a PDF since 2024-10-12.

## What this PR removes

| | |
|---|---|
| `requirements.txt` | `mkdocs-with-pdf` and `weasyprint`, installed on every docs build, used by nothing |
| `mkdocs.yml` | the commented-out `with-pdf` plugin block |
| `tools/mkArmbianDocs.py` | an **active** `with-pdf` entry in the mkdocs.yml it generates |

The third one is the reason this is worth doing rather than leaving be. `DOCUMENTATION.md` tells contributors to re-run `tools/mkArmbianDocs.py` after adding files, and that script would have written a live `with-pdf` plugin back into `mkdocs.yml` — now pointing at dependencies that are no longer installed.

`mkdocs build --clean` succeeds after the change.

## Not touched

`.github/workflows/pdf-at-pr.yaml` is **not** a PDF workflow despite its filename. It is "Create docs preview on PR" and only runs `mkdocs build`; its single occurrence of "pdf" is its own filename inside a badge URL. Deleting it would have removed PR previews. The name is misleading and could be renamed separately.


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pdf-at-pr.yaml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1178"><kbd><br> Open WWW preview <br></kbd></a>

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1178"><kbd><br> Open WWW preview <br></kbd></a>