### PR TITLE
Harden workflows: pin third-party actions, scope GITHUB_TOKEN

### DIFF
--- a/.github/workflows/apt-repo-status.yml
+++ b/.github/workflows/apt-repo-status.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: ${{ github.event_name != 'pull_request' }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: docs/status/package-repository.md

--- a/.github/workflows/build-machinery-status.yml
+++ b/.github/workflows/build-machinery-status.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: docs/status/build-machinery.md

--- a/.github/workflows/clean-workflow-logs.yml
+++ b/.github/workflows/clean-workflow-logs.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: igorjs/gh-actions-clean-workflow@v7
+      - uses: igorjs/gh-actions-clean-workflow@5fa2e3a4fdd40e3e7098645a0b8df08624352e5e # v7.0.1
         with:
           runs_older_than: ${{ github.event.inputs.runs_older_than || env.SCHEDULED_RUNS_OLDER_THAN }}
           runs_to_keep: ${{ github.event.inputs.runs_to_keep || env.SCHEDULED_RUNS_TO_KEEP }}

--- a/.github/workflows/download-images-status.yml
+++ b/.github/workflows/download-images-status.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: ${{ github.event_name != 'pull_request' }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: docs/status/download-images.md

--- a/.github/workflows/labels-from-yml.yml
+++ b/.github/workflows/labels-from-yml.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v6
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: PauMAVA/add-remove-label-action@v1.0.3
+      - uses: PauMAVA/add-remove-label-action@d1dae9b1a6c5b44b7740a3e7f64723fe7c9619d3 # v1.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add: ""
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.5.7"
+        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Comment on PR with preview link
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: devindford/Append_PR_Comment@v1.1.3
+        uses: devindford/Append_PR_Comment@32dd2619cd96ac8da9907c416c992fe265233ca8 # v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           body-template: |

--- a/.github/workflows/pull-extensions-list.yml
+++ b/.github/workflows/pull-extensions-list.yml
@@ -51,7 +51,7 @@ jobs:
             > documentation/docs/build-framework/extensions/list.md
 
       - name: Create Pull Request to documentation
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: documentation

--- a/.github/workflows/pull-from-armbian-config.yml
+++ b/.github/workflows/pull-from-armbian-config.yml
@@ -6,6 +6,11 @@ on:
       - master
   workflow_dispatch:
 
+# create-pull-request commits a branch and opens a PR with GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
 
   Build:

--- a/.github/workflows/pull-from-armbian-config.yml
+++ b/.github/workflows/pull-from-armbian-config.yml
@@ -61,7 +61,7 @@ jobs:
         run: python3 documentation/tools/build-software-nav.py
 
       - name: Create Pull Request to documentation
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: documentation

--- a/.github/workflows/pull-mirrors-from-db.yml
+++ b/.github/workflows/pull-mirrors-from-db.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Create Pull Request to documentation
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: documentation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Only reads this repository: the build is published over rsync with a deploy
+# key, so GITHUB_TOKEN needs no write access at all.
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     name: "Generate HTML"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         run: mkdocs build --clean
 
       - name: "Install SSH key"
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.KEY_UPLOAD }}
           known_hosts: ${{ secrets.HOST_APPLICATIONS_KNOWN_HOSTS }}


### PR DESCRIPTION
> **TL;DR** — Two mechanical hardening changes from reviewing all 11 workflows: pin third-party actions to SHAs, and scope the two workflows that were inheriting a write-all token. Neither changes what any workflow does.

## 1. Pin third-party actions to commit SHAs

Every third-party action was referenced by tag. Tags are mutable — the action's owner can repoint one at different code and the next run picks it up silently.

| Action | was | now |
|---|---|---|
| `shimataro/ssh-key-action` | `v2` | `87a8f067` (v2.8.1) |
| `peter-evans/create-pull-request` | `v8` | `5f6978fa` (v8.1.1) |
| `crazy-max/ghaction-github-labeler` | `v6` | `548a7c36` (v6.0.0) |
| `devindford/Append_PR_Comment` | `v1.1.3` | `32dd2619` (v1.1.3) |
| `igorjs/gh-actions-clean-workflow` | `v7` | `5fa2e3a4` (v7.0.1) |
| `pascalgn/size-label-action` | `v0.5.7` | `56b489b0` (v0.5.7) |
| `PauMAVA/add-remove-label-action` | `v1.0.3` | `d1dae9b1` (v1.0.3) |

`shimataro/ssh-key-action` is the one that matters: `release.yaml` hands it the docs deploy private key. Its resolved SHA is the same one **armbian/autotests already pins**, so the two repos now agree.

Every SHA is what the tag pointed at as of this PR, so the same code runs as before. Versions are kept in trailing comments, so Dependabot can still bump them.

`actions/*` are left on tags — first-party and lower risk; pinning them too is defensible but adds churn to every bump.

## 2. Scope `GITHUB_TOKEN` on the two workflows that had no `permissions:`

The repo default is **write** (`default_workflow_permissions: "write"`), so a workflow without a `permissions:` block gets write access to every scope. Nine of eleven already declare what they need; these two didn't.

- **`release.yaml` → `contents: read`.** It checks out, builds, installs a deploy key and rsyncs — it never uses `GITHUB_TOKEN`. It's also the workflow holding the deploy secrets, so an unnecessary write token is least welcome here.
- **`pull-from-armbian-config.yml` → `contents: write` + `pull-requests: write`**, which is what `peter-evans/create-pull-request` actually uses. Same capability, stated rather than inherited.

All 11 workflows still parse.

## Not changed, but worth knowing

While reviewing, two things turned up that need a decision rather than a mechanical fix:

**`pull-from-armbian-config.yml` has a dead push trigger.** It's gated on `branches: [ master ]`, like the announce workflows just removed. All **10** of its runs were `workflow_dispatch` — the push trigger has never fired. Repointing it at `main` would start it running automatically on every push, which is a behaviour change, so it's left alone here.

**`labels-from-yml.yml` has 0 runs but is fine.** It's correctly gated on changes to `.github/labels.yml`, which has been modified exactly once — in the commit that added it. Idle by design, not broken; noting it so it doesn't get mistaken for dead.

`pr-auto-labeler.yml` uses `pull_request_target` but does *not* have the dangerous pattern: its `actions/checkout` has no `ref:`, so it takes the base branch rather than fork code. No `${{ github.event.* }}` reaches any `run:` block in any workflow.


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1180"><kbd><br> Open WWW preview <br></kbd></a>