### PR TITLE
Run the config sync on a daily cron instead of a dead push trigger

### DIFF
--- a/.github/workflows/pull-from-armbian-config.yml
+++ b/.github/workflows/pull-from-armbian-config.yml
@@ -1,9 +1,11 @@
 name: "Pull from Armbian config"
 
 on:
-  push:
-    branches:
-      - master
+  # Regenerated from armbian/configng, so nothing in this repository
+  # should trigger it. Daily at 04:30 UTC, clear of the 05:00 mirrors
+  # and 06:00/06:30 status jobs.
+  schedule:
+    - cron: '30 4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
> **TL;DR** — The config sync has never actually triggered: it's gated on a `master` branch this repo doesn't use. Fix it with a daily cron rather than a push trigger, because push is the wrong signal here.

## The problem

```yaml
on:
  push:
    branches:
      - master
```

There is no `master`. All **10** of this workflow's runs, ever, were manual `workflow_dispatch` — the push trigger has never fired once.

## Why not just point it at `main`

That was the first instinct, but push is the wrong trigger for this job:

- **Its inputs aren't in this repo.** It regenerates the config documentation from `armbian/configng`, and checks out `armbian/documentation` with no `ref:` — i.e. the default branch. A push here doesn't change what it produces.
- **`main` is busy.** 218 commits in the last 14 days, roughly 16 pushes a day, mostly automated status and fleet-result updates. It would have run ~16 times daily to regenerate the same output.

## The fix

A daily schedule, matching how the sibling syncs already work — `pull-mirrors-from-db.yml` is on a schedule, `pull-extensions-list.yml` on `repository_dispatch`.

```yaml
on:
  schedule:
    - cron: '30 4 * * *'
  workflow_dispatch:
```

04:30 UTC is a free slot: ahead of the 05:00 mirrors job and the 06:00 / 06:30 status jobs.

`workflow_dispatch` stays, since on-demand is how this workflow has actually been used until now.

## Note

If picking up configng changes promptly matters more than a daily cadence, `repository_dispatch` fired from configng would be the closer fit — same pattern as `pull-extensions-list.yml`. That needs a change on the configng side too, so it isn't done here.


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1181"><kbd><br> Open WWW preview <br></kbd></a>