### PR TITLE
DOCUMENTATION.md: drop the dead PDF link

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -14,11 +14,6 @@ Documentation is written in [markdown](https://www.markdownguide.org/basic-synta
 
 This repo is meant for storing and quick glances.  Official output is [https://docs.armbian.com](https://docs.armbian.com).
 
-Armbian Documentation is available in the following formats:
-
-* [Official document website](https://docs.armbian.com),
-* [PDF document](https://github.com/armbian/documentation/releases/latest)
-
 ## Contributing
 
 This site is built with [mkdocs](https://github.com/mkdocs/mkdocs/) and depends on [mkdocs-material](https://github.com/squidfunk/mkdocs-material).


### PR DESCRIPTION
`DOCUMENTATION.md` advertised the docs in two formats:

```markdown
Armbian Documentation is available in the following formats:

* [Official document website](https://docs.armbian.com),
* [PDF document](https://github.com/armbian/documentation/releases/latest)
```

The PDF build was retired in 2024 and its releases have since been deleted — all 242 of them, along with the SHA-named tags they hung off. That link now just redirects to an empty releases page.

With the PDF gone there's only one format left, and the line immediately above already says where it's published:

> This repo is meant for storing and quick glances.  Official output is https://docs.armbian.com.

So the list goes entirely, rather than shrinking to a single bullet repeating the sentence before it.

## Scope

Only the stale link. The other `pdf` mentions in the docs are unrelated and stay:

- PDF viewers listed in the desktop tiers (`docs/config/desktops.md`, `docs/build-framework/desktops.md`)
- the Stirling PDF application pages (`docs/software/stirling.md`, `docs/User-Guide_Armbian-Software/`)

The remaining `releases/latest` links point at `armbian/os` image releases, which are live.

The same dead link appears in the README rewrite in #942; removed there on that branch.


[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1182"><kbd><br> Open WWW preview <br></kbd></a>