### PR TITLE
docs(contribute): add S5P6818 as a new-board(-family) example

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -26,8 +26,9 @@ If you are struggling, check [WEB](https://www.exchangecore.com/blog/contributin
 
 There are no detailed instructions on how to add a new board or even a whole new board family to the build script yet. However there are a few commits / pull requests that give clues how to achieve that like
 
-- [https://github.com/armbian/build/pull/3176/files](https://github.com/armbian/build/pull/3176/files)
-- [https://github.com/armbian/build/pull/3138/files](https://github.com/armbian/build/pull/3138/files)
+- [A whole new SoC family — Nexell S5P6818 (NanoPC-T3+, NanoPi M3, NanoPi Fire3)](https://github.com/armbian/build/pull/10674): a recent, end-to-end example — three board configs, a new family definition, boot environment and boot script, a kernel config, u-boot support, and the full mainline bring-up patch series.
+- [https://github.com/armbian/build/pull/3176](https://github.com/armbian/build/pull/3176)
+- [https://github.com/armbian/build/pull/3138](https://github.com/armbian/build/pull/3138)
 
 ## Board maintainer
 


### PR DESCRIPTION
The **Adding a new board?** section on [/contribute/](https://docs.armbian.com/contribute/) only linked two 2021-era PRs. Adds [armbian/build#10674](https://github.com/armbian/build/pull/10674/files) — the Nexell **S5P6818** bring-up (NanoPC-T3+ / NanoPi M3 / NanoPi Fire3) — as a recent, end-to-end example that shows what a *whole new SoC family* takes: three board configs, a new family definition, boot env/script, a kernel config, u-boot support, and the full mainline patch series.

`mkdocs build --strict` passes.

Signed-off-by: Igor Pecovnik <igor@armbian.com>

[![Create docs preview on PR](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml/badge.svg)](https://github.com/armbian/documentation/actions/workflows/pr-docs-preview.yml)

Documentation website preview will be available shortly:

<a href="https://armbian.github.io/documentation/1208"><kbd><br> Open WWW preview <br></kbd></a>